### PR TITLE
Remove +Support and +AaaS traits

### DIFF
--- a/roles/README.md
+++ b/roles/README.md
@@ -19,8 +19,6 @@ traits and be achieving current traits before taking on more.
 
 **Engineer**:
 
-* [+Support](engineer.md#support)
-* [+AaaS](engineer.md#aaas)
 * [+Lead](engineer.md#lead)
 
 **Business**:

--- a/roles/engineer.md
+++ b/roles/engineer.md
@@ -12,7 +12,7 @@ We need someone:
 
 We expect someone in the role:
 
-- to be billable for at least half their time after 2 weeks on-boarding
+- to be fully billable after 2 weeks on-boarding
 - to be involved in practice improvement discussions within 3 months
 - to be actively practicing modern software craftsmanship practices such as TDD within 3 months
 - to be autonomously delivering features of a small nature within 3 months
@@ -31,7 +31,6 @@ We need someone:
 
 We expect someone in the role:
 
-- to be fully billable after 2 weeks on-boarding
 - to need less than 1 day per week of Technical Director involvement in their deliveries
 - to be mentoring middleweight developers on their team within 2 months
 - to be improving our practices across the business within 3 months

--- a/roles/engineer.md
+++ b/roles/engineer.md
@@ -12,36 +12,13 @@ We need someone:
 
 We expect someone in the role:
 
+- to be billable for at least half their time after 2 weeks on-boarding
 - to be involved in practice improvement discussions within 3 months
 - to be actively practicing modern software craftsmanship practices such as TDD within 3 months
 - to be autonomously delivering features of a small nature within 3 months
 - to be autonomously delivering features of a medium nature within 6 months
 
 ## Engineer traits
-
-### +Support
-
-We need someone:
-
-- to deliver work in accordance to our support contracts
-- to liaise with support customers
-
-We expect someone in the role:
-
-- to be billable for at least half their time within 3 months
-
-### +AaaS
-
-We need someone:
-
-- to join a sprint team
-- to be billed on a day-rate as part of a AaaS team
-
-We expect someone in the role:
-
-- to be fully billable after 2 weeks on-boarding
-- to be able to autonomously deliver features of a mid-level of complexity within 1 month
-- to deliver features of a higher level of complexity with support of more experienced developers within 3 months
 
 ### +Lead
 


### PR DESCRIPTION
We are removing these traits as we no longer see a separation between Support and AaaS work. Engineers should be able to move freely between our various offerings.