### PR TITLE
1. Replace +Lead with idea of emerging Engineer Leadership

### DIFF
--- a/roles/engineer.md
+++ b/roles/engineer.md
@@ -56,3 +56,13 @@ We need someone:
 
  - to provide a mentorship role to a colleague
  - to encourage learning across the company
+
+## Engineer Leadership
+
+Traits recognise value that Engineers can provide customers and the company. They are hats and as Engineers develop their skills, Engineers will begin to wear more of those hats. Leadership is a quality that emerges out of individual traits. The longer an Engineer wears a trait the more of a leader in that area they will become.
+
+Engineer Leadership is a property that emerges when an individual becomes a leader across multiple traits and starts to perform more vital roles within engagements with customers.
+
+When an Engineer becomes a leader in +Customer and +Delivery they will naturally begin to be the primary point of contact with the customer for the engagement. As an Engineer gets more experience, their responsibilities will grow and their role in the team will evolve. Relationships will naturally develop between emerging leaders and customers as their seniority leads them to take more responsibility for the delivery and therefore will require them to be in contact with the customer more.
+
+Our aim by introducing traits is to provide banners under which we can develop our skills and as leaders emerge we will call on these Engineers to take responsibility such as overall ownership of engagements and communication with customers.

--- a/roles/engineer.md
+++ b/roles/engineer.md
@@ -50,21 +50,6 @@ We need someone:
  - to regularly improve our process for delivering software
  - to ensure the done done completion of tasks
 
-### +Lead
-
-We need someone:
-
-- to foster good engineering standards on a project
-- to be the primary day-to-day client liaison on technology-lead deliveries
-- to mentor developers on their team
-- to drive process improvements on their team
-
-We expect someone in the role:
-
-- to need less than 1 day per week of Technical Director involvement in their deliveries
-- to be mentoring middleweight developers on their team within 2 months
-- to be improving our practices across the business within 3 months
-
 ### +Mentor
 
 We need someone:


### PR DESCRIPTION
Previously we used +Lead to encompass the properties that are required to ensure engagements go smoothly. As we developed the traits we wish to encourage we've seen more and more of the expectations of +Lead fall under other traits and therefore feel +Lead isn't a trait in and of itself.

Engineer Leadership should be recognised, and is useful when forming teams. A primary point of contact and someone responsible for the commercial success of an engagement is required within a team in order for that team and engagement to run itself. However rather than grouping expectations around +Lead we recognise Leadership as an emergent property when an Engineers begins to exhibit more and more traits.