### PR TITLE
Clarify inclusion around Friday Lunches

### DIFF
--- a/benefits/friday_lunch_drinks.md
+++ b/benefits/friday_lunch_drinks.md
@@ -12,6 +12,8 @@ Few rules:
 
 * Whoever is involved in organising team lunch is responsible for ensuring that everyone who wants to eat can do so with respect to their dietary requirements.
 
+* If a work emergency comes up and keeps you from attending lunch you may order in and expense it and also request many merits from your colleagues for being a star!
+
 * We trust people to use their judgement as to what is a reasonable amount to spend on a team lunch.
 
 * Where possible, encourage customers to join us for lunch and / or drinks. 

--- a/benefits/friday_lunch_drinks.md
+++ b/benefits/friday_lunch_drinks.md
@@ -8,7 +8,9 @@ Few rules:
 
 * One of the directors will pick-up the tab for lunch. If we're not around, somebody with a company card should be able to cover lunch, or it can be put through as an expense claim.
 
-* Whoever is involved in organising team lunch is responsible for ensuring that it is an inclusive activity for all of the team. 
+* Generally we want everyone to eat together but if we go to a restaurant which excludes certain people like non-meateaters, meateaters and folk with other dietary requirements then a second option may be chosen and expensed. The majority of our restaurant list is friendly to all requirements :)
+
+* Whoever is involved in organising team lunch is responsible for ensuring that everyone who wants to eat can do so with respect to their dietary requirements.
 
 * We trust people to use their judgement as to what is a reasonable amount to spend on a team lunch.
 


### PR DESCRIPTION
This change should make it clear that generally we want everyone to eat together, and lunch must always be inclusive to dietary requirements.

In order to have a wider variety of restaurants on our rota, including vegan and meat only restaurants, we are clear that on those weeks if a dietary requirements are excluded then those excluded may go to a second restaurant of their choice and expense it too.