### PR TITLE
Split friday lunch and drinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ We're a company that moves fast, so we're going to need everyone to help us keep
 * [Untracked Holiday Allowance](benefits/untracked_holiday.md)
 * [Flexible Working](benefits/flexible_working.md)
 * [Company Credit Cards](benefits/company_credit_card.md)
-* [Friday Lunches & Drinks](benefits/friday_lunch_drinks.md)
+* [Friday Lunches](benefits/friday_lunch.md)
 * [Remote Working](benefits/remote_working.md)
 * [Season Ticket Loan](benefits/season_ticket_loan.md)
 * [Cycle To Work Scheme](benefits/cycle_to_work_scheme.md)
 * [Working Hours](benefits/working_hours.md)
+* [Friday Drinks](benefits/friday_drinks.md)
 
 ### Welfare
 

--- a/benefits/friday_drinks.md
+++ b/benefits/friday_drinks.md
@@ -1,0 +1,15 @@
+# Friday Drinks
+
+Every Friday we'll pay for post-work drinks. This weekly ritual provides an opportunity for the team to socialise.
+
+As drinking is exclusionary in nature to those who don't like or can't be around alcohol we make efforts to make sure it's not the center of our culture whilst at the same time acknowledging it's important to some.
+
+Few rules:
+
+* When going for Friday drinks, we'll cover the tab whilst one of the directors is around (and offering to pay). After that, you'll be on your own and drinks should come out of your own pocket.
+
+* Remember you're still representing the business when you are out drinking. Be respectful and decent at all times.
+
+* Where possible, encourage customers to join us for drinks. 
+
+* We encourage you to invite friends of Made Tech and people we might consider hiring to Friday drinks. It's a good opportunity to meet both socially. 

--- a/benefits/friday_lunch.md
+++ b/benefits/friday_lunch.md
@@ -1,8 +1,6 @@
-# Friday Lunch & Drinks
+# Friday Lunch
 
-Every Friday we'll pay for a team lunch and post-work drinks. 
-
-This weekly ritual provides an opportunity for the team to socialise and share their successes and challenges from the week that's passed. It's important that we continue to set aside the time for this, especially when we have teams working at customers offices regularly.
+Every Friday we pay for a team lunch.  This weekly ritual provides an opportunity for the team to socialise and share their successes and challenges from the week that's passed. It's important that we continue to set aside the time for this, especially when we have teams working at customers offices regularly.
 
 Few rules:
 
@@ -16,8 +14,4 @@ Few rules:
 
 * We trust people to use their judgement as to what is a reasonable amount to spend on a team lunch.
 
-* Where possible, encourage customers to join us for lunch and / or drinks. 
-
-* When going for Friday drinks, we'll cover the tab whilst one of the directors is around (and offering to pay). After that, you'll be on your own and drinks should come out of your own pocket.
-
-* We encourage you to invite friends of Made Tech and people we might consider hiring to Friday drinks. It's a good opportunity to meet both socially. 
+* Where possible, encourage customers to join us for lunch.


### PR DESCRIPTION
Splitting these concepts apart as lunch is an inclusive affair whereas drinks are implicitly exclusive to those who like to frequent pubs and such.