### PR TITLE
Move communication expectation into Engineer role

### DIFF
--- a/roles/as_code/lib/engineer.rb
+++ b/roles/as_code/lib/engineer.rb
@@ -9,5 +9,8 @@ JobSpec::Role.definition 'Engineer' do
   expected 'to be fully billable',
     'We expect our Engineers to be fully billed on customers deliveries as we are a business trying to make a profit by delivering valuable working software to our customers.'
 
+  expected 'to regularly communicate with customers without reminder',
+    'We expect our Engineers to be communicating with our customers daily through their standups, but also throughout the day via Slack. Everyone should feel empowered to ask customers questions, communicate progress and demonstrate successes.'
+
   include CoreEngineerExpectations, as: 'Core Engineer Expectations'
 end

--- a/roles/as_code/lib/shared_expectations/core_engineer_expectations.rb
+++ b/roles/as_code/lib/shared_expectations/core_engineer_expectations.rb
@@ -11,9 +11,6 @@ class CoreEngineerExpectations < JobSpec::Role::Expectations
   expected 'to provide meaningful and considerate peer reviews for others',
     'We expect our engineering team to provide feedback that makes code safer, easier to maintain and advances the knowledge of the original author. We expect everyone to negotiate and compromise when making a call on whether feedback should be addressed or not.'
 
-  expected 'to regularly communicate with customers without reminder',
-    'We expect our Engineers to be communicating with our customers daily through their standups, but also throughout the day via Slack. Everyone should feel empowered to ask customers questions, communicate progress and demonstrate successes.'
-
   expected 'to keep their team updated on current work in progress',
     'We expect our Engineers to keep their fellow team members up to date with their progress. A good litmus test for this is everyone on the team can describe what their team mates are up to.'
 


### PR DESCRIPTION
This expectation isn't shared with Reliability Engineer so should be specific to Engineer.