### PR TITLE
Add security to core engineering expectations

### DIFF
--- a/roles/academy_engineer.md
+++ b/roles/academy_engineer.md
@@ -42,6 +42,10 @@ We expect our Engineers to keep their fellow team members up to date with their 
 
 We expect our Engineers to be able to demonstrate the successes of their iterations with weekly showcases to customers. We also expect Engineers to be able to facilitate retrospectives with engaging formats and customer involvement. Good teams will rotate this responsibility on a weekly basis.
 
+### To be responsible for the security of devices used for work
+
+We expect everyone in our team to understand how to secure the devices they use for work including work issued laptops, personal computers, mobile phones, and other electronic devices. We expect invididuals to ensure they adhere to our [security guidelines](https://github.com/madetech/handbook/blob/master/guides/security/protect_the_company.md) upon setting up devices and to ensure that their machines are compliant at all times.
+
 ### To be involved in practice improvement discussions
 
 We expect everyone in our team to reflect on our practices and be a proactive voice in suggesting change. We expect you to be reflecting on your own development practices, reflecting on your team and the wider business.

--- a/roles/as_code/lib/shared_expectations/core_engineer_expectations.rb
+++ b/roles/as_code/lib/shared_expectations/core_engineer_expectations.rb
@@ -17,6 +17,9 @@ class CoreEngineerExpectations < JobSpec::Role::Expectations
   expected 'to facilitate showcases and retrospectives',
     'We expect our Engineers to be able to demonstrate the successes of their iterations with weekly showcases to customers. We also expect Engineers to be able to facilitate retrospectives with engaging formats and customer involvement. Good teams will rotate this responsibility on a weekly basis.'
 
+  expected 'to be responsible for the security of devices used for work',
+    'We expect everyone in our team to understand how to secure the devices they use for work including work issued laptops, personal computers, mobile phones, and other electronic devices. We expect invididuals to ensure they adhere to our [security guidelines](https://github.com/madetech/handbook/blob/master/guides/security/protect_the_company.md) upon setting up devices and to ensure that their machines are compliant at all times.'
+
   expected 'to be involved in practice improvement discussions',
     'We expect everyone in our team to reflect on our practices and be a proactive voice in suggesting change. We expect you to be reflecting on your own development practices, reflecting on your team and the wider business.'
 end

--- a/roles/engineer.md
+++ b/roles/engineer.md
@@ -82,6 +82,10 @@ We expect our Engineers to keep their fellow team members up to date with their 
 
 We expect our Engineers to be able to demonstrate the successes of their iterations with weekly showcases to customers. We also expect Engineers to be able to facilitate retrospectives with engaging formats and customer involvement. Good teams will rotate this responsibility on a weekly basis.
 
+### To be responsible for the security of devices used for work
+
+We expect everyone in our team to understand how to secure the devices they use for work including work issued laptops, personal computers, mobile phones, and other electronic devices. We expect invididuals to ensure they adhere to our [security guidelines](https://github.com/madetech/handbook/blob/master/guides/security/protect_the_company.md) upon setting up devices and to ensure that their machines are compliant at all times.
+
 ### To be involved in practice improvement discussions
 
 We expect everyone in our team to reflect on our practices and be a proactive voice in suggesting change. We expect you to be reflecting on your own development practices, reflecting on your team and the wider business.

--- a/roles/lead_engineer.md
+++ b/roles/lead_engineer.md
@@ -150,6 +150,10 @@ We expect our Engineers to keep their fellow team members up to date with their 
 
 We expect our Engineers to be able to demonstrate the successes of their iterations with weekly showcases to customers. We also expect Engineers to be able to facilitate retrospectives with engaging formats and customer involvement. Good teams will rotate this responsibility on a weekly basis.
 
+### To be responsible for the security of devices used for work
+
+We expect everyone in our team to understand how to secure the devices they use for work including work issued laptops, personal computers, mobile phones, and other electronic devices. We expect invididuals to ensure they adhere to our [security guidelines](https://github.com/madetech/handbook/blob/master/guides/security/protect_the_company.md) upon setting up devices and to ensure that their machines are compliant at all times.
+
 ### To be involved in practice improvement discussions
 
 We expect everyone in our team to reflect on our practices and be a proactive voice in suggesting change. We expect you to be reflecting on your own development practices, reflecting on your team and the wider business.

--- a/roles/reliability_engineer.md
+++ b/roles/reliability_engineer.md
@@ -112,6 +112,10 @@ We expect our Engineers to keep their fellow team members up to date with their 
 
 We expect our Engineers to be able to demonstrate the successes of their iterations with weekly showcases to customers. We also expect Engineers to be able to facilitate retrospectives with engaging formats and customer involvement. Good teams will rotate this responsibility on a weekly basis.
 
+### To be responsible for the security of devices used for work
+
+We expect everyone in our team to understand how to secure the devices they use for work including work issued laptops, personal computers, mobile phones, and other electronic devices. We expect invididuals to ensure they adhere to our [security guidelines](https://github.com/madetech/handbook/blob/master/guides/security/protect_the_company.md) upon setting up devices and to ensure that their machines are compliant at all times.
+
 ### To be involved in practice improvement discussions
 
 We expect everyone in our team to reflect on our practices and be a proactive voice in suggesting change. We expect you to be reflecting on your own development practices, reflecting on your team and the wider business.


### PR DESCRIPTION
We are adding security expectations to all roles to ensure everyone has followed the security guidelines we've defined for keeping our devices secure. This hasn't been made clear to new starters in the past but want to ensure going forward everyone is made aware of what they are personally responsible for in terms of the security of their devices.