### PR TITLE
Add BAU expectations

### DIFF
--- a/team-norms/bau_expectations.md
+++ b/team-norms/bau_expectations.md
@@ -6,7 +6,7 @@ The Made Tech Support Team requirements are identified below. Where the applicat
 
 ## Application Requirements
 
-- Centralised Logging (Loggly)
+- Centralised Logging (Papertrail)
 - Application Performance Monitoring (Datadog)
 - Exception Tracking (Sentry)
 - Automated Dependency Upgrades (Dependabot)

--- a/team-norms/bau_expectations.md
+++ b/team-norms/bau_expectations.md
@@ -1,0 +1,20 @@
+# Business As Usual (BAU) Expectations
+
+Teams must deliver software systems in accordance with our Business As Usual Expectations that make software systems easier to run, debug, and improve.
+
+The Made Tech Support Team requirements are identified below. Where the application is transitioning to a customer support team, you should liaise with the customer team to understand their specific needs.
+
+## Application Requirements
+
+- Centralised Logging (Loggly)
+- Application Performance Monitoring (Datadog)
+- Exception Tracking (Sentry)
+- Automated Dependency Upgrades (Dependabot)
+- Automated Security Patches (Snyk)
+
+## Platform Requirements
+
+- IaC provisioning (Ansible)
+- Server Monitoring (Datadog)
+- Automated Security Patching (operating system provided)
+- NTP synchronisation

--- a/team-norms/delivery_standards.md
+++ b/team-norms/delivery_standards.md
@@ -28,7 +28,7 @@ Every team is expected to practice Continuous Delivery from the first iteration.
 
 ## 5. Productionise Application
 
-Every team is expected to deliver a production-ready application from the first iteration. The team must provide centralised application and infrastructure logging, application exception tracking, application performance monitoring, and automated dependency and security upgrades.
+Every team is expected to deliver a production-ready application from the first iteration according to our [BAU expectations](bau_expectations.md).
 
 ## 6. Use Pull Requests
 


### PR DESCRIPTION
A list of things an application and platform must provided to be considered ready for our Support Team to run