### PR TITLE
Add explicit expectations between employees and the org

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ We're a company that moves fast, so we're going to need everyone to help us keep
 * [Sick Leave](guides/welfare/sick_leave.md)
 * [State of Mind](guides/welfare/state_of_mind.md)
 * [Employee Assistance](guides/welfare/employee_assistance.md)
+* [Expectations between Employees and the Organisation](guides/welfare/expectations.md)
 * [Raising an Issue](guides/welfare/raising_an_issue.md)
 * [Parental Leave](guides/welfare/parental_leave.md)
 

--- a/guides/welfare/expectations.md
+++ b/guides/welfare/expectations.md
@@ -1,0 +1,21 @@
+# Expectations between Made Tech and staff
+
+As an employee embarking on a career with Made Tech you will have expectations about what that means in terms of your role within the organisation, job security, progression, work life balance and having a comfortable workplace. Made Tech too will have expectations on the employee in terms of your role, impact on the team, net contribution and increasing that contribution over time.
+
+We think these expectations create a healthy tension between employee and employer and we seek to be explicit about these expectations all of the time. There should be no surprises.
+
+The healthy tension is a good thing because it means together the individual has their needs met by their employment and the organisation gets closer to achieving its vision due to the contribution of the employee.
+
+## Employees expectations of Made Tech
+
+As an employee I expect Made Tech to clearly define my role within the business as well as career progression paths. I also expect for Made Tech to provide me with a comfortable workplace and respect my right to a healthy work life balance. Finally, I expect Made Tech to hold itself accountable against the company values.
+
+If the staff expectations are not being met by the organisation then we encourage staff to [raise an issue](../welfare/raising_an_issue.md). The only way issues can be addressed is by discussing them and working constructively to improving the situation, everything needs work, organisations are no different.
+
+## Made Tech expectations of staff
+
+As an organisation we expect an employee to understand their role within the business and meet the expectations of their role. We also expect employees to provide a net positive contribution to achieving the companies vision.
+
+Role expectations should be introduced as part of the onboarding process for all roles. Expectations should be reviewed on a regular (usually monthly) basis with a Director or Line Manager.
+
+From time to time, an issue with an employee not meeting expectations will occur. Team members may also occasionally have concerns over the performance of their colleagues. We can perform an [expectation health check](#expectation_health_check.md) in this case.

--- a/guides/welfare/expectations.md
+++ b/guides/welfare/expectations.md
@@ -1,6 +1,6 @@
 # Expectations between Made Tech and staff
 
-As an employee embarking on a career with Made Tech you will have expectations about what that means in terms of your role within the organisation, job security, progression, work life balance and having a comfortable workplace. Made Tech too will have expectations on the employee in terms of your role, impact on the team, net contribution and increasing that contribution over time.
+As an employee embarking on a career with Made Tech you will have expectations about what that means in terms of your role within the organisation, job security, progression, work life balance and having a comfortable workplace. Made Tech too will have expectations on the employee in terms of the role they play in the organisation.
 
 We think these expectations create a healthy tension between employee and employer and we seek to be explicit about these expectations all of the time. There should be no surprises.
 
@@ -10,12 +10,10 @@ The healthy tension is a good thing because it means together the individual has
 
 As an employee I expect Made Tech to clearly define my role within the business as well as career progression paths. I also expect for Made Tech to provide me with a comfortable workplace and respect my right to a healthy work life balance. Finally, I expect Made Tech to hold itself accountable against the company values.
 
-If the staff expectations are not being met by the organisation then we encourage staff to [raise an issue](../welfare/raising_an_issue.md). The only way issues can be addressed is by discussing them and working constructively to improving the situation, everything needs work, organisations are no different.
+If the staff expectations are not being met by the organisation then we encourage staff to [raise an issue](../welfare/raising_an_issue.md). The only way issues can be resolved is by discussing them and working constructively to improve the situation. Everything needs work, organisations are no different.
 
 ## Made Tech expectations of staff
 
-As an organisation we expect an employee to understand their role within the business and meet the expectations of their role. We also expect employees to provide a net positive contribution to achieving the companies vision.
-
-Role expectations should be introduced as part of the onboarding process for all roles. Expectations should be reviewed on a regular (usually monthly) basis with a Director or Line Manager.
+As an organisation we expect an employee to understand their role within the business and meet the expectations of their role. Role expectations should be introduced as part of the onboarding process for all roles. Expectations should be reviewed on a regular (usually monthly) basis with a Director or Line Manager.
 
 From time to time, an issue with an employee not meeting expectations will occur. Team members may also occasionally have concerns over the performance of their colleagues. We can perform an [expectation health check](#expectation_health_check.md) in this case.


### PR DESCRIPTION
We already list our values in the Handbook but I think it’s important for us to be explicit about the healthy tension between the expectations of employees and the organisation.

These expectations also set the context for escalation procedures for employees to raise an issue and also for the organisation to escalate issues with employees.

**Further Background**

One of our People objectives for Q2 (and Q1 but things got away from me...) is to provide an escalation procedure in the Handbook when expectations aren’t being met. We already have this for employees to [raise an issue](https://github.com/madetech/handbook/blob/master/guides/welfare/raising_an_issue.md), we are now looking at it from the other way when an employee isn’t meeting the expectations of their role.

A future PR will include the expectation health check linked to along with more formal capability procedures.