### PR TITLE
Add Health Check and Escalation for Expectation Issues

### DIFF
--- a/guides/process/people/capability_procedure.md
+++ b/guides/process/people/capability_procedure.md
@@ -1,0 +1,26 @@
+# Capability Procedure
+
+In cases where employees are not meeting the expectations that have been clearly defined to them, and after an expectation health check has been performed, we follow the [Acas Code of Practice on Discipline Procedures](http://www.acas.org.uk/publications).
+
+## Expectation Health Check
+
+Before we escalate to formal proceedings, an expectation health check will be performed by a Director. Capability Procedures usually include measures to identify and address issues, our expectation health check seeks to address issues before reaching that stage.
+
+In the case where a health check has failed to address issues raised, a formal performance review procedure will be followed.
+
+## Formal Performance Review
+
+- Step 1: If it is decided a formal performance review must be carried out, Made Tech will notify the employee in writing of the reasons why and be invited to a meeting to discuss the problem.
+- Step 2: Made Tech will then hold the meeting to discuss the problem, allowing the employee to present their case. The employee has the right to bring a companion* with them.
+- Step 3: Made Tech will then decide on appropriate action to be taken. If it is decided that the employee has been performing unsatisfactorily, the employee will be a written warning that includes the details of the performance issue, and the timescale in which the issue must be addressed.
+- Step 4: If the issue has not been rectified within the time period, a final written warning will be issued stating another timescale in which the issue must be addressed and the consequences if the issue is not addressed.
+
+\*Companion can include a paid official of a trade union, a lay trade union official that can provide evidence of experience in these matters, or a colleague. In certain circumstances we may also allow representatives from other organisations if particularly relevant to the grievance such as Citizens Advice Bureau.
+
+## Consequences of a not addressing a final written warning
+
+The most likely consequence of not addressing concerns within the time period set out in a final written warning will be dismissal. Other consequences may include demotion or loss of seniority.
+
+The employee will be informed as soon as possible of the reasons of their dismissal, the date on which the employment contract will end, the appropriate period of notice and their right to appeal.
+
+Where an employee feels that the decision of dismissal is wrong or unjust they should appeal against the decision. Appeals will be heard within a reasonable timeframe in the form of a meeting. Employees should let Made Tech know the grounds for their appeal in writing. Employees have the right to be accompanied in their appeal meeting. Made Tech will then notify the employee in writing the results of the appeal hearing as soon as possible.

--- a/guides/process/people/capability_procedure.md
+++ b/guides/process/people/capability_procedure.md
@@ -12,7 +12,7 @@ In the case where a health check has failed to address issues raised, a formal p
 
 - Step 1: If it is decided a formal performance review must be carried out, Made Tech will notify the employee in writing of the reasons why and be invited to a meeting to discuss the problem.
 - Step 2: Made Tech will then hold the meeting to discuss the problem, allowing the employee to present their case. The employee has the right to bring a companion* with them.
-- Step 3: Made Tech will then decide on appropriate action to be taken. If it is decided that the employee has been performing unsatisfactorily, the employee will be a written warning that includes the details of the performance issue, and the timescale in which the issue must be addressed.
+- Step 3: Made Tech will then decide on appropriate action to be taken. If it is decided that the employee has been performing unsatisfactorily, the employee will be given a written warning that includes the details of the performance issue, and the timescale in which the issue must be addressed.
 - Step 4: If the issue has not been rectified within the time period, a final written warning will be issued stating another timescale in which the issue must be addressed and the consequences if the issue is not addressed.
 
 \*Companion can include a paid official of a trade union, a lay trade union official that can provide evidence of experience in these matters, or a colleague. In certain circumstances we may also allow representatives from other organisations if particularly relevant to the grievance such as Citizens Advice Bureau.

--- a/guides/welfare/expectation_health_check.md
+++ b/guides/welfare/expectation_health_check.md
@@ -1,0 +1,49 @@
+# Expectation Health Check
+
+We believe the expectations between Made Tech and staff create a healthy tension that has a positive impact on both in equal measure. Occasionally these expectations will not be met for one reason or another. If Made Tech is not meeting the expectations of staff, an employee can [raise an issue](raising_an_issue.md).
+
+In the case where an employee is not meeting the expectations of Made Tech or another member of staff we can perform an expectation health check. This document outlines the procedure.
+
+## What to do before requesting a health check
+
+Before a health check is requested, we recommend issues are raised as informally as possible. Very much similar to the start of our [raising an issue](raising_an_issue.md) guidance we recommend the following steps.
+
+### Before a health check have a conversation with the person involved
+
+The first thing you can do, if you feel comfortable and able, is raise the issue directly with the person involved. This type of direct and informal approach is encouraged and we expect your colleagues who are approached responsibly to respond in a similar manner. By vocally mentioning that an expectation is not being met or that performance is less than expected, the member of staff can reflect and work to improve the situation, seeking help where necessary.
+
+### Before a health check raise feedback via Continuous Feedback
+
+If you feel unable to have a conversation directly with the person involved, and they are a member of staff at Made Tech then you can encourage them to discuss the issue in their next [continuous feedback](../../team-norms/continuous_feedback.md) session by raising the feedback through that process.
+
+Continuous feedback is not anonymous but can add a layer of indirection and ensure that the issue is discussed with another member of the team. We hope this will trigger conversations amongst those in the session and we would expect proactive action to happen off the back of that session.
+
+### Before a health check ask a colleague to intervene on your behalf
+
+You may ask a colleague or director to intervene informally on your behalf. In some situations you may not feel able to directly approach the person or people involved and so going via a third party to informally raise your concern for you is another option available to you.
+
+## How to request a health check
+
+If the previous steps have not led to expectations being met or performance being improved then you can request a health check. You can request a health check from a Director. Once you request a health check the following steps will be taken:
+
+- Director will book a meeting in ASAP with whoever requested a health check to discuss their concerns
+- If the Director feels appropriate informal steps have been unsuccessful in improving the situation a meeting will be booked with the employee concerned to discuss the issue and the impact it's having on the organisation
+- If the issue is not addressed within two weeks or the situation escalates then the Director will notify the employee that an expectation health check will be performed
+
+## Performing a health check
+
+The purpose of a health check is to clearly identify expectations that are not being met and then to define clear steps to be taken to resolve the situation. Health checks are a slightly more formal process for being explicit about issues, it is not a capability procedure or performance review.
+
+The following steps will be taken in order to perform the health check:
+
+- Director will book a meeting with the employee who has been identified as not meeting expectations, the purpose of the meeting is to clearly define expectations that are not currently being met, these expectations will then be sent in writing to the employee along with instructions for next steps
+- The employee will be asked to identify causes (illness and mental wellbeing are valid causes!) for why the expectations are not being met and define steps that can be taken to address the situation
+- The employee will then be invited to share their thoughts ahead of another meeting
+- During the next meeting the Director will either agree with, or suggest changes to the employees identified causes, steps for addressing and a timescale in which they are to be addressed. If the employee has been unable to identify causes and steps for addressing the Director will define these with the employee
+- The plan will then be sent in writing to the employee
+- On a weekly basis the plan will be reviewed and based on feedback from both the employee and if necessary their colleagues the Director will track progress towards achieving the plan
+- We expect the health check to be reviewed and resolved within the defined timescale
+
+## What to do if a health check cannot resolve an issue
+
+In some cases, the health check will be unsuccessful in its aim of addressing unmet expectations. In this case, our formal [capability procedure](../process/people/capability_procedure.md) will be followed.

--- a/guides/welfare/expectations.md
+++ b/guides/welfare/expectations.md
@@ -16,4 +16,4 @@ If the staff expectations are not being met by the organisation then we encourag
 
 As an organisation we expect an employee to understand their role within the business and meet the expectations of their role. Role expectations should be introduced as part of the onboarding process for all roles. Expectations should be reviewed on a regular (usually monthly) basis with a Director or Line Manager.
 
-From time to time, an issue with an employee not meeting expectations will occur. Team members may also occasionally have concerns over the performance of their colleagues. We can perform an [expectation health check](#expectation_health_check.md) in this case.
+From time to time, an issue with an employee not meeting expectations will occur. Team members may also occasionally have concerns over the performance of their colleagues. We can perform an [expectation health check](expectation_health_check.md) in this case.


### PR DESCRIPTION
Continuing on from yesterdays PR #146 we add an Expectation Health Check document along with a Capability Procedure.

## Purpose of Expectation Health Check

The purpose of the Expectation Health Check is to provide a holistic feedback cycle to ensure we uncover any issues that may be causing someone to not meet the expectations of their role. We need to ensure they are fit and healthy, that they are getting the support they need, we identify clearly what needs to change and we put a plan in place for getting there.

## Purpose of Capability Procedure

The Capability Procedure is a standard HR document for escalating performance issues in the worst case which can lead to written warnings and dismissal. The hope is that the Expectation Health Check can resolve almost all issues however we should have a more formal process in place too.

As usual feedback welcome!