### PR TITLE
Link to About Made Tech rather than mission

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We're a company that moves fast, so we're going to need everyone to help us keep
 
 ### Introduction to Made Tech
 
-* [Our Mission](company/mission_statement.md)
+* [About Made Tech](company/about.md)
 * [Welcome Pack](company/welcome_pack.md)
 
 ### Roles

--- a/company/about.md
+++ b/company/about.md
@@ -1,0 +1,17 @@
+# About Made Tech
+
+Made Tech's mission is to improve software delivery in every organisation. 
+
+**We build software delivery capabilities, deliver digital & technology, and run live services for ambitious organisations.**
+
+Our delivery-focused approach enables customers to unleash innovation and reduce time-to-market, so they spend less time battling 'business as usual', and more time delivering real business value.
+
+We come from a background of helping hungry startups get to market fast, so we know how to ship software quickly. We are renowned for our expertise in extreme programming, lean, and agile practices.
+
+Today we’re partnering with some of the UK’s largest organisations, driving the adoption of modern software delivery practices while delivering innovative applications, and untangling legacy IT estates.
+
+Our customers are forward-thinking executives who need help to: 
+
+- **Build software delivery capabilities:** we work alongside in-house teams, helping them to learn by doing. We coach teams to ship software using modern practices such as test-driven development, continuous delivery and DevOps. 
+- **Deliver digital and technology:** we build new products and modernise legacy applications using technologies such as container platforms, microservice architectures, and cloud automation.
+- **Run live services:** our reliability engineers proactively monitor, maintain, and improve cloud infrastructure and applications, driving quality up, and the cost of change down. 

--- a/company/mission_statement.md
+++ b/company/mission_statement.md
@@ -1,7 +1,0 @@
-# Our mission
-
-> Our mission is to improve software delivery in every organisation.
-
-We've seen many organisations constrained by poor choices when it comes to software. Whether it's keeping a slow legacy system around, or neglecting a team that needs help, these decisions impede an organisation's ability to compete in a competitive world.
-
-We believe there's a better way, one that encourages an open and collaborative relationship with everyone involved, and one that places importance on the ability to deliver great software quickly.


### PR DESCRIPTION
Why? Because we have a mission statement in the README. It'd be good to provide more detail about Made Tech instead.

We are decommissioning the old mission statement as part of this change.