### PR TITLE
Rename Competencies -> Core Skills

### DIFF
--- a/roles/as_code/lib/engineer.rb
+++ b/roles/as_code/lib/engineer.rb
@@ -56,8 +56,8 @@ JobSpec::Role.definition 'Engineer' do
   expected 'to be fully billable',
     'We expect our Engineers to significantly contribute to customer deliveries, to justify billing their time. Without billing customers, Made Tech isn\'t a sustainable business.'
 
-  expected 'to be working towards the Made Tech Core Engineering Competencies',
-    'We expect our Engineers to be honing their craft, practising at every opportunity and consistently making progress towards attaining all the Made Tech Core Engineering Competencies.'
+  expected 'to be working towards the Made Tech Core Skills',
+    'We expect our Engineers to be honing their craft, practising at every opportunity and consistently making progress towards attaining all the Made Tech Core Skills.'
 
   include CoreEngineerExpectations, as: 'Core Engineer Expectations'
 end

--- a/roles/as_code/lib/shared_expectations/senior_engineer_expectations.rb
+++ b/roles/as_code/lib/shared_expectations/senior_engineer_expectations.rb
@@ -2,8 +2,8 @@ class SeniorEngineerExpectations < JobSpec::Role::Expectations
   expected 'to make sensible and well justified technical architecture decisions, involving the team in the decision making process where appropriate',
     'We expect our Senior Engineers to be able to design and implement appropriate technical architectures to solve problems. We expect them to appropriately involve the team in the decision making process to help them develop their technical architecture skills.'
 
-  expected 'to have attained the Made Tech Core Engineering Competencies',
-    'We expect our Senior Engineers to be an expert in their craft, practising and coaching others in the Made Tech Core Engineering Competencies.'
+  expected 'to have attained the Made Tech Core Skills',
+    'We expect our Senior Engineers to be an expert in their craft, practising and coaching others in the Made Tech Core Skills'
 
   expected 'to be willing and able to pick up new programming languages, technologies and techniques',
     'We expect our Senior Engineers to be actively researching and trialling new technologies and techniques. We expect them to be regularly sharing their knowledge whether that is during focussed learning sessions, talks, or via pairing.'

--- a/roles/engineer.md
+++ b/roles/engineer.md
@@ -56,9 +56,9 @@ We expect our Engineers to be able to work on entire features, from conception t
 
 We expect our Engineers to significantly contribute to customer deliveries, to justify billing their time. Without billing customers, Made Tech isn't a sustainable business.
 
-### To be working towards the Made Tech Core Engineering Competencies
+### To be working towards the Made Tech Core Skills
 
-We expect our Engineers to be honing their craft, practising at every opportunity and consistently making progress towards attaining all the Made Tech Core Engineering Competencies.
+We expect our Engineers to be honing their craft, practising at every opportunity and consistently making progress towards attaining all the Made Tech Core Skills.
 
 ## Core Engineer Expectations
 

--- a/roles/lead_engineer.md
+++ b/roles/lead_engineer.md
@@ -123,9 +123,9 @@ We expect our Delivery Leads to be an expert in the application of agile and lea
 
 We expect our Senior Engineers to be able to design and implement appropriate technical architectures to solve problems. We expect them to appropriately involve the team in the decision making process to help them develop their technical architecture skills.
 
-### To have attained the Made Tech Core Engineering Competencies
+### To have attained the Made Tech Core Skills
 
-We expect our Senior Engineers to be an expert in their craft, practising and coaching others in the Made Tech Core Engineering Competencies.
+We expect our Senior Engineers to be an expert in their craft, practising and coaching others in the Made Tech Core Skills
 
 ### To be willing and able to pick up new programming languages, technologies and techniques
 

--- a/roles/senior_engineer.md
+++ b/roles/senior_engineer.md
@@ -63,9 +63,9 @@ We expect our Senior Engineers to proactively provide thoughtful and meaningful 
 
 We expect our Senior Engineers to be able to design and implement appropriate technical architectures to solve problems. We expect them to appropriately involve the team in the decision making process to help them develop their technical architecture skills.
 
-### To have attained the Made Tech Core Engineering Competencies
+### To have attained the Made Tech Core Skills
 
-We expect our Senior Engineers to be an expert in their craft, practising and coaching others in the Made Tech Core Engineering Competencies.
+We expect our Senior Engineers to be an expert in their craft, practising and coaching others in the Made Tech Core Skills
 
 ### To be willing and able to pick up new programming languages, technologies and techniques
 


### PR DESCRIPTION
Was going through expectations and saw this inconsistency with internal naming