### PR TITLE
Add Customer Support Rep role to Handbook

### DIFF
--- a/roles/as_code/lib/customer_support_representative.rb
+++ b/roles/as_code/lib/customer_support_representative.rb
@@ -1,0 +1,82 @@
+require_relative './shared_expectations/live_services_expectations'
+
+JobSpec::Role.definition 'Customer Support Representative' do
+  description <<~DESCRIPTION
+    Our Customer Support Reps are point of contact for our Live Services customers. They are great communicators, love to plan, and want what's best for everyone.
+
+    ## What does the job entail?
+
+    Made Tech are growing and winning more new projects with both existing and new customers. We have a reliability engineering team responsible for running live services for our customers and delivering a roadmap of improvement for applications and infrastructure including new software features, automation, bug fixes and support issues. Due to our customer base expanding and the number of projects growing, we’re experiencing an increase in technical support enquiries.
+
+    We need a dedicated, single point of contact to deal quickly and effectively with our customer support issues in an empathetic and customer focused way, triaging and escalating queries to ensure effective use of time and swift resolution.
+
+    This role will report to our Delivery and Operations Director and liaise directly with both customers and reliability engineers, some of whom work remotely.
+
+    Day-to-day you will receive incoming requests such as outages, error messages and performance issues from a variety of sources including Slack, email, video calls on Google Hangouts, etc. You will triage the enquiry to either escalate accordingly (e.g. high priority systems outages) or add to our backlog (low priority e.g. small bug fixes or systems performance issues), responding to all customer queries using ZenDesk to manage email queries and triage.
+
+    You will escalate high priority issues to our reliability engineers and add low priority requests to the roadmap to be addressed at a later date. We use Asana to stay organised, so you will add each request to our customer boards as you receive them.
+
+    You will act as single point of contact to ensure customers are informed and updated on the status of their technical support enquiry. You will also lead fortnightly reviews with each customer, discussing what has been delivered in previous iterations and which priorities remain for the following two weeks.
+
+    Over time you will form detailed knowledge of the various applications we have created for customers, including their purpose, functionality, hosting, metrics and permissions. This is information you will use to make support more effective, resolving issues yourself if needed, and continuing to ensure ever more effective triaging where not.
+
+    The role offers a great deal of variety. Each of our customers uses a unique piece software with unique integrations and business purposes. We know of few support roles where the issues you are called upon to triage and resolve are so varied.
+
+    This role provides the opportunity to progress your career in multiple different areas, including shaping or even leading our live services function as it grows. You might also decide to explore a career more centred around customer relationships, account management or service delivery depending on where your aspirations lie.
+
+    ## What experience are we looking for?
+
+    First and foremost, we pride ourselves in the absolute highest level of customer support, requiring a customer-focused attitude from our whole team, willing to go above and beyond to provide an exceptional experience and solution for each customer. You will be naturally outgoing and able to build rapport quickly with a variety of personalities and need to demonstrate the confidence and credibility to engage politely and appropriately with our customers and our internal teams.
+
+    We’re looking for someone who has previously fielded calls and emails from software users and triaged these issues to the relevant technical or functional team for resolution. This may have been application support, customer services in a software business or product support – key is that you understand how to track and escalate basic software issues for resolution.
+
+    You’ll be able to talk to us about the ticketing system – whether formal or informal – used in your current or previous work place and explain your role ensuring tickets were triaged and escalated efficiently and accurately.
+
+    You will possess excellent communication skills both verbal and written, including emailing and calling customers to explain ticket statuses, giving guidance or actually resolving issues personally.
+
+    You will be able to talk about times when you’ve dealt with customer issues around software or networks in an empathetic manner whilst managing customer expectations. We will need you to provide honest and accurate estimates about completion time-frames whilst empathising with customer issues or frustrations.
+
+    You'll have a sharp attention to detail that allows you to understand our customers quickly and identify issues intuitively from information provided, identifying recurring problems and taking measures to improve service. You should stay calm and be polite at all times, and we expect you to be able to talk about times when you have stayed calm throughout times of stress by staying organised and prioritising your workload.
+
+    ## What is it like to work at Made Tech?
+
+    We are a technology focussed business that values continuous improvement, experimentation, trusting individuals and teams to do the right thing.
+
+    We are a growing business and now is a good time to join us as there is great opportunity to have a massive impact on the business and grow with us too.
+
+    ## Salary
+
+    This role has a salary of £20-30k depending on experience.
+  DESCRIPTION
+
+  salary 20_000..30_000
+
+  expected 'to keep customer roadmaps up to date with fortnightly calls',
+    'We expect Customer Support Reps to be keeping customer roadmaps up to date with their priorities at least every fortnight with a call. Reliability Engineers need to know what the customer\'s next highest priority and roadmaps should be reflective of this.'
+
+  expected 'to work with reliability engineers to estimate time ranges for features, improvements and bug fixes',
+    'We expect Customer Support Reps to ensure all items in customer roadmaps have time range estimates in them. It is a collective responsibility for the Live Services team to make sure these are up to date.'
+
+  expected 'to ensure customer roadmaps combine business value and reduction of technical debt',
+    'We expect Customer Support Reps to ensure items in customer roadmaps contain a mix of features, improvements and bug fixes that provide business value, as well as items that reduce technical debt over time. Customers often prefer the former and so effort must be spent to educate the important of reducing technical debt.'
+
+  expected 'to work with reliability engineers to schedule 28 hours of work per week per engineer',
+    'We expect Live Services to be as profitable as possible given its shared resourcing model. We have set the minimum number of scheduled hours for Reliability Engineers to 28 hours per week representing 4 days of 7 hours billed. We expect Customer Support Reps to support Reliability Engineers achieving this expectation by managing a fortnightly schedule.'
+
+  expected 'to protect development time so we can keep to our committed delivery schedule',
+    'We expect Customer Support Reps to protect Reliability Engineers scheduled development time by handling Support Desk queries, only allowing P1 issues to take a Reliability Engineer away from their scheduled work. All other work must be prioritised in the roadmap and then picked up by Reliability Engineers in the next available timeslot for that customer.'
+
+  expected 'to ensure customers and team are using correct avenues of contact',
+    'We expect Customer Support Reps to ensure customers use the Support Desk, Slack and Google Hangouts for contacting Live Services. Support Desk should be used to manage open tickets rather than Slack. Any work that can be scheduled should be tracked in the customer roadmap.'
+
+  expected 'to build and maintain relationships with senior budget holders',
+    'We expect Customer Support Reps to build relationships with senior budget holders as well as their day-to-day contacts. This is because often day-to-day contacts won\'t be empowered to make commercial decisions such as agreeing top-ups or change of subscription level.'
+
+  expected 'to be accountable for customer happiness',
+    'We expect Customer Support Reps to maintain high levels of customer happiness and to proactively escalate issues that are damaging to our reputation with a customer.'
+
+  expected 'to ensure team ceremonies are carried out regularly',
+    'We expect Customer Support Reps to ensure team ceremonies such as planning, retrospectives, and standups happen on a regular basis.'
+
+  include LiveServicesExpectations, as: 'Live Services Expectations'
+end

--- a/roles/as_code/lib/reliability_engineer.rb
+++ b/roles/as_code/lib/reliability_engineer.rb
@@ -1,4 +1,5 @@
 require_relative './shared_expectations/core_engineer_expectations'
+require_relative './shared_expectations/live_services_expectations'
 
 JobSpec::Role.definition 'Reliability Engineer' do
   description <<~DESCRIPTION
@@ -66,20 +67,9 @@ JobSpec::Role.definition 'Reliability Engineer' do
   expected 'to be fully billable by timesheeting 7 hours daily',
     'We expect our Reliability Engineers to ensure they are timesheeting 7 hours daily into harvest. As our current offering means we offer hours to our customers we need to make sure we are working through these hours and providing value to our customers.'
 
-  expected 'to regularly communicate with customers without reminder',
-    'We expect our Reliability Engineers to keep their fellow team members up to date with their progress. A good litmus test for this is everyone on the team can describe what their team mates are up to.'
-
-  expected 'to be a responsible remote worker',
-    'We expect our Reliability Engineers to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels like email and slack.'
-
-  expected 'to effectively juggle commitments',
-    'We expect our Reliability Engineers to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Customers expectations need to be set, met and if they cannot be met, be reset early and often.'
-
-  expected 'to provide an outstanding customer service',
-    'We expect our Reliability Engineers to be a delightful person to talk to for our customers. Our conversations should be professional and friendly, we should small talk where possible, use a smiley face once in a while and generally be nice folk.'
-
   expected 'to proactively identify technical improvements and recommend them to customers',
     'We expect our Reliability Engineers to be able to spot areas for improvement in customer codebases such as test suites, dependency upgrades, performance issues detected by monitoring. We also expect them to be able to highlight these issues in a jargon free way and be able to convey the relative urgency of the issues ultimately leading to our customer codebases being improved.'
 
+  include LiveServicesExpectations, as: 'Live Services Expectations'
   include CoreEngineerExpectations, as: 'Core Engineer Expectations'
 end

--- a/roles/as_code/lib/shared_expectations/live_services_expectations.rb
+++ b/roles/as_code/lib/shared_expectations/live_services_expectations.rb
@@ -1,0 +1,10 @@
+class LiveServicesExpectations < JobSpec::Role::Expectations
+  expected 'to provide an outstanding customer service',
+    'We expect our Live Services team to be delightful to interact with. Our conversations should be professional and friendly, we should small talk where possible, use a smiley face once in a while and generally be nice folk.'
+
+  expected 'to be a responsible remote worker',
+    'We expect our Live Services team to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels such as email and Slack.'
+
+  expected 'to effectively juggle commitments',
+    'We expect our Live Services team to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Customer expectations need to be set and met. If they cannot be met they should be reset early and often.'
+end

--- a/roles/customer_support_representative.md
+++ b/roles/customer_support_representative.md
@@ -1,0 +1,100 @@
+# Customer Support Representative
+
+Our Customer Support Reps are point of contact for our Live Services customers. They are great communicators, love to plan, and want what's best for everyone.
+
+## What does the job entail?
+
+Made Tech are growing and winning more new projects with both existing and new customers. We have a reliability engineering team responsible for running live services for our customers and delivering a roadmap of improvement for applications and infrastructure including new software features, automation, bug fixes and support issues. Due to our customer base expanding and the number of projects growing, we’re experiencing an increase in technical support enquiries.
+
+We need a dedicated, single point of contact to deal quickly and effectively with our customer support issues in an empathetic and customer focused way, triaging and escalating queries to ensure effective use of time and swift resolution.
+
+This role will report to our Delivery and Operations Director and liaise directly with both customers and reliability engineers, some of whom work remotely.
+
+Day-to-day you will receive incoming requests such as outages, error messages and performance issues from a variety of sources including Slack, email, video calls on Google Hangouts, etc. You will triage the enquiry to either escalate accordingly (e.g. high priority systems outages) or add to our backlog (low priority e.g. small bug fixes or systems performance issues), responding to all customer queries using ZenDesk to manage email queries and triage.
+
+You will escalate high priority issues to our reliability engineers and add low priority requests to the roadmap to be addressed at a later date. We use Asana to stay organised, so you will add each request to our customer boards as you receive them.
+
+You will act as single point of contact to ensure customers are informed and updated on the status of their technical support enquiry. You will also lead fortnightly reviews with each customer, discussing what has been delivered in previous iterations and which priorities remain for the following two weeks.
+
+Over time you will form detailed knowledge of the various applications we have created for customers, including their purpose, functionality, hosting, metrics and permissions. This is information you will use to make support more effective, resolving issues yourself if needed, and continuing to ensure ever more effective triaging where not.
+
+The role offers a great deal of variety. Each of our customers uses a unique piece software with unique integrations and business purposes. We know of few support roles where the issues you are called upon to triage and resolve are so varied.
+
+This role provides the opportunity to progress your career in multiple different areas, including shaping or even leading our live services function as it grows. You might also decide to explore a career more centred around customer relationships, account management or service delivery depending on where your aspirations lie.
+
+## What experience are we looking for?
+
+First and foremost, we pride ourselves in the absolute highest level of customer support, requiring a customer-focused attitude from our whole team, willing to go above and beyond to provide an exceptional experience and solution for each customer. You will be naturally outgoing and able to build rapport quickly with a variety of personalities and need to demonstrate the confidence and credibility to engage politely and appropriately with our customers and our internal teams.
+
+We’re looking for someone who has previously fielded calls and emails from software users and triaged these issues to the relevant technical or functional team for resolution. This may have been application support, customer services in a software business or product support – key is that you understand how to track and escalate basic software issues for resolution.
+
+You’ll be able to talk to us about the ticketing system – whether formal or informal – used in your current or previous work place and explain your role ensuring tickets were triaged and escalated efficiently and accurately.
+
+You will possess excellent communication skills both verbal and written, including emailing and calling customers to explain ticket statuses, giving guidance or actually resolving issues personally.
+
+You will be able to talk about times when you’ve dealt with customer issues around software or networks in an empathetic manner whilst managing customer expectations. We will need you to provide honest and accurate estimates about completion time-frames whilst empathising with customer issues or frustrations.
+
+You'll have a sharp attention to detail that allows you to understand our customers quickly and identify issues intuitively from information provided, identifying recurring problems and taking measures to improve service. You should stay calm and be polite at all times, and we expect you to be able to talk about times when you have stayed calm throughout times of stress by staying organised and prioritising your workload.
+
+## What is it like to work at Made Tech?
+
+We are a technology focussed business that values continuous improvement, experimentation, trusting individuals and teams to do the right thing.
+
+We are a growing business and now is a good time to join us as there is great opportunity to have a massive impact on the business and grow with us too.
+
+## Salary
+
+This role has a salary of £20-30k depending on experience.
+
+
+## Expectations
+
+### To keep customer roadmaps up to date with fortnightly calls
+
+We expect Customer Support Reps to be keeping customer roadmaps up to date with their priorities at least every fortnight with a call. Reliability Engineers need to know what the customer's next highest priority and roadmaps should be reflective of this.
+
+### To work with reliability engineers to estimate time ranges for features, improvements and bug fixes
+
+We expect Customer Support Reps to ensure all items in customer roadmaps have time range estimates in them. It is a collective responsibility for the Live Services team to make sure these are up to date.
+
+### To ensure customer roadmaps combine business value and reduction of technical debt
+
+We expect Customer Support Reps to ensure items in customer roadmaps contain a mix of features, improvements and bug fixes that provide business value, as well as items that reduce technical debt over time. Customers often prefer the former and so effort must be spent to educate the important of reducing technical debt.
+
+### To work with reliability engineers to schedule 28 hours of work per week per engineer
+
+We expect Live Services to be as profitable as possible given its shared resourcing model. We have set the minimum number of scheduled hours for Reliability Engineers to 28 hours per week representing 4 days of 7 hours billed. We expect Customer Support Reps to support Reliability Engineers achieving this expectation by managing a fortnightly schedule.
+
+### To protect development time so we can keep to our committed delivery schedule
+
+We expect Customer Support Reps to protect Reliability Engineers scheduled development time by handling Support Desk queries, only allowing P1 issues to take a Reliability Engineer away from their scheduled work. All other work must be prioritised in the roadmap and then picked up by Reliability Engineers in the next available timeslot for that customer.
+
+### To ensure customers and team are using correct avenues of contact
+
+We expect Customer Support Reps to ensure customers use the Support Desk, Slack and Google Hangouts for contacting Live Services. Support Desk should be used to manage open tickets rather than Slack. Any work that can be scheduled should be tracked in the customer roadmap.
+
+### To build and maintain relationships with senior budget holders
+
+We expect Customer Support Reps to build relationships with senior budget holders as well as their day-to-day contacts. This is because often day-to-day contacts won't be empowered to make commercial decisions such as agreeing top-ups or change of subscription level.
+
+### To be accountable for customer happiness
+
+We expect Customer Support Reps to maintain high levels of customer happiness and to proactively escalate issues that are damaging to our reputation with a customer.
+
+### To ensure team ceremonies are carried out regularly
+
+We expect Customer Support Reps to ensure team ceremonies such as planning, retrospectives, and standups happen on a regular basis.
+
+## Live Services Expectations
+
+### To provide an outstanding customer service
+
+We expect our Live Services team to be delightful to interact with. Our conversations should be professional and friendly, we should small talk where possible, use a smiley face once in a while and generally be nice folk.
+
+### To be a responsible remote worker
+
+We expect our Live Services team to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels such as email and Slack.
+
+### To effectively juggle commitments
+
+We expect our Live Services team to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Customer expectations need to be set and met. If they cannot be met they should be reset early and often.

--- a/roles/reliability_engineer.md
+++ b/roles/reliability_engineer.md
@@ -66,25 +66,23 @@ We expect our Reliability Engineers to be able to work on entire features, from 
 
 We expect our Reliability Engineers to ensure they are timesheeting 7 hours daily into harvest. As our current offering means we offer hours to our customers we need to make sure we are working through these hours and providing value to our customers.
 
-### To regularly communicate with customers without reminder
-
-We expect our Reliability Engineers to keep their fellow team members up to date with their progress. A good litmus test for this is everyone on the team can describe what their team mates are up to.
-
-### To be a responsible remote worker
-
-We expect our Reliability Engineers to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels like email and slack.
-
-### To effectively juggle commitments
-
-We expect our Reliability Engineers to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Customers expectations need to be set, met and if they cannot be met, be reset early and often.
-
-### To provide an outstanding customer service
-
-We expect our Reliability Engineers to be a delightful person to talk to for our customers. Our conversations should be professional and friendly, we should small talk where possible, use a smiley face once in a while and generally be nice folk.
-
 ### To proactively identify technical improvements and recommend them to customers
 
 We expect our Reliability Engineers to be able to spot areas for improvement in customer codebases such as test suites, dependency upgrades, performance issues detected by monitoring. We also expect them to be able to highlight these issues in a jargon free way and be able to convey the relative urgency of the issues ultimately leading to our customer codebases being improved.
+
+## Live Services Expectations
+
+### To provide an outstanding customer service
+
+We expect our Live Services team to be delightful to interact with. Our conversations should be professional and friendly, we should small talk where possible, use a smiley face once in a while and generally be nice folk.
+
+### To be a responsible remote worker
+
+We expect our Live Services team to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels such as email and Slack.
+
+### To effectively juggle commitments
+
+We expect our Live Services team to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Customer expectations need to be set and met. If they cannot be met they should be reset early and often.
 
 ## Core Engineer Expectations
 


### PR DESCRIPTION
As part of ensuring every role is documented in the Handbook I submit the Customer Support Rep role for review.

In particular looking to discuss the expectations for this role.