### PR TITLE
Add “To regularly communicate with customers” expectation to Core Engineer

### DIFF
--- a/roles/academy_engineer.md
+++ b/roles/academy_engineer.md
@@ -34,6 +34,10 @@ We expect our engineering team to always have their code peer reviewed at the le
 
 We expect our engineering team to provide feedback that makes code safer, easier to maintain and advances the knowledge of the original author. We expect everyone to negotiate and compromise when making a call on whether feedback should be addressed or not.
 
+### To regularly communicate with customers without reminder
+
+We expect our Engineers to keep their customers up to date with progress. Customers should be invited to standups or at appropriate points in time. A customer should never have to chase us for an update.
+
 ### To keep their team updated on current work in progress
 
 We expect our Engineers to keep their fellow team members up to date with their progress. A good litmus test for this is everyone on the team can describe what their team mates are up to.

--- a/roles/as_code/lib/shared_expectations/core_engineer_expectations.rb
+++ b/roles/as_code/lib/shared_expectations/core_engineer_expectations.rb
@@ -11,6 +11,9 @@ class CoreEngineerExpectations < JobSpec::Role::Expectations
   expected 'to provide meaningful and considerate peer reviews for others',
     'We expect our engineering team to provide feedback that makes code safer, easier to maintain and advances the knowledge of the original author. We expect everyone to negotiate and compromise when making a call on whether feedback should be addressed or not.'
 
+  expected 'to regularly communicate with customers without reminder',
+    'We expect our Engineers to keep their customers up to date with progress. Customers should be invited to standups or at appropriate points in time. A customer should never have to chase us for an update.'
+
   expected 'to keep their team updated on current work in progress',
     'We expect our Engineers to keep their fellow team members up to date with their progress. A good litmus test for this is everyone on the team can describe what their team mates are up to.'
 

--- a/roles/engineer.md
+++ b/roles/engineer.md
@@ -78,6 +78,10 @@ We expect our engineering team to always have their code peer reviewed at the le
 
 We expect our engineering team to provide feedback that makes code safer, easier to maintain and advances the knowledge of the original author. We expect everyone to negotiate and compromise when making a call on whether feedback should be addressed or not.
 
+### To regularly communicate with customers without reminder
+
+We expect our Engineers to keep their customers up to date with progress. Customers should be invited to standups or at appropriate points in time. A customer should never have to chase us for an update.
+
 ### To keep their team updated on current work in progress
 
 We expect our Engineers to keep their fellow team members up to date with their progress. A good litmus test for this is everyone on the team can describe what their team mates are up to.

--- a/roles/lead_engineer.md
+++ b/roles/lead_engineer.md
@@ -157,6 +157,10 @@ We expect our engineering team to always have their code peer reviewed at the le
 
 We expect our engineering team to provide feedback that makes code safer, easier to maintain and advances the knowledge of the original author. We expect everyone to negotiate and compromise when making a call on whether feedback should be addressed or not.
 
+### To regularly communicate with customers without reminder
+
+We expect our Engineers to keep their customers up to date with progress. Customers should be invited to standups or at appropriate points in time. A customer should never have to chase us for an update.
+
 ### To keep their team updated on current work in progress
 
 We expect our Engineers to keep their fellow team members up to date with their progress. A good litmus test for this is everyone on the team can describe what their team mates are up to.

--- a/roles/reliability_engineer.md
+++ b/roles/reliability_engineer.md
@@ -104,6 +104,10 @@ We expect our engineering team to always have their code peer reviewed at the le
 
 We expect our engineering team to provide feedback that makes code safer, easier to maintain and advances the knowledge of the original author. We expect everyone to negotiate and compromise when making a call on whether feedback should be addressed or not.
 
+### To regularly communicate with customers without reminder
+
+We expect our Engineers to keep their customers up to date with progress. Customers should be invited to standups or at appropriate points in time. A customer should never have to chase us for an update.
+
 ### To keep their team updated on current work in progress
 
 We expect our Engineers to keep their fellow team members up to date with their progress. A good litmus test for this is everyone on the team can describe what their team mates are up to.

--- a/roles/senior_engineer.md
+++ b/roles/senior_engineer.md
@@ -97,6 +97,10 @@ We expect our engineering team to always have their code peer reviewed at the le
 
 We expect our engineering team to provide feedback that makes code safer, easier to maintain and advances the knowledge of the original author. We expect everyone to negotiate and compromise when making a call on whether feedback should be addressed or not.
 
+### To regularly communicate with customers without reminder
+
+We expect our Engineers to keep their customers up to date with progress. Customers should be invited to standups or at appropriate points in time. A customer should never have to chase us for an update.
+
 ### To keep their team updated on current work in progress
 
 We expect our Engineers to keep their fellow team members up to date with their progress. A good litmus test for this is everyone on the team can describe what their team mates are up to.


### PR DESCRIPTION
This used to exist. No idea where it went. Time to add it back!