### PR TITLE
Add expectation for team members to uphold team ceremonies

### DIFF
--- a/roles/academy_engineer.md
+++ b/roles/academy_engineer.md
@@ -42,6 +42,10 @@ We expect our engineering team to keep their customers up to date with progress.
 
 We expect our engineering team to keep their fellow team members up to date with their progress. A good litmus test for this is everyone on the team can describe what their team mates are up to.
 
+### To ensure team ceremonies are held regularly
+
+We expect our engineering team to ensure team ceremonies such as planning, retrospectives, and standups happen on a regular basis.
+
 ### To facilitate showcases and retrospectives
 
 We expect our engineering team to be able to demonstrate the successes of their iterations with weekly showcases to customers. We also expect Engineers to be able to facilitate retrospectives with engaging formats and customer involvement. Good teams will rotate this responsibility on a weekly basis.

--- a/roles/as_code/lib/shared_expectations/core_engineer_expectations.rb
+++ b/roles/as_code/lib/shared_expectations/core_engineer_expectations.rb
@@ -17,6 +17,9 @@ class CoreEngineerExpectations < JobSpec::Role::Expectations
   expected 'to keep their team updated on current work in progress',
     'We expect our engineering team to keep their fellow team members up to date with their progress. A good litmus test for this is everyone on the team can describe what their team mates are up to.'
 
+  expected 'to ensure team ceremonies are held regularly',
+    'We expect our engineering team to ensure team ceremonies such as planning, retrospectives, and standups happen on a regular basis.'
+
   expected 'to facilitate showcases and retrospectives',
     'We expect our engineering team to be able to demonstrate the successes of their iterations with weekly showcases to customers. We also expect Engineers to be able to facilitate retrospectives with engaging formats and customer involvement. Good teams will rotate this responsibility on a weekly basis.'
 

--- a/roles/engineer.md
+++ b/roles/engineer.md
@@ -86,6 +86,10 @@ We expect our engineering team to keep their customers up to date with progress.
 
 We expect our engineering team to keep their fellow team members up to date with their progress. A good litmus test for this is everyone on the team can describe what their team mates are up to.
 
+### To ensure team ceremonies are held regularly
+
+We expect our engineering team to ensure team ceremonies such as planning, retrospectives, and standups happen on a regular basis.
+
 ### To facilitate showcases and retrospectives
 
 We expect our engineering team to be able to demonstrate the successes of their iterations with weekly showcases to customers. We also expect Engineers to be able to facilitate retrospectives with engaging formats and customer involvement. Good teams will rotate this responsibility on a weekly basis.

--- a/roles/lead_engineer.md
+++ b/roles/lead_engineer.md
@@ -165,6 +165,10 @@ We expect our engineering team to keep their customers up to date with progress.
 
 We expect our engineering team to keep their fellow team members up to date with their progress. A good litmus test for this is everyone on the team can describe what their team mates are up to.
 
+### To ensure team ceremonies are held regularly
+
+We expect our engineering team to ensure team ceremonies such as planning, retrospectives, and standups happen on a regular basis.
+
 ### To facilitate showcases and retrospectives
 
 We expect our engineering team to be able to demonstrate the successes of their iterations with weekly showcases to customers. We also expect Engineers to be able to facilitate retrospectives with engaging formats and customer involvement. Good teams will rotate this responsibility on a weekly basis.

--- a/roles/reliability_engineer.md
+++ b/roles/reliability_engineer.md
@@ -112,6 +112,10 @@ We expect our engineering team to keep their customers up to date with progress.
 
 We expect our engineering team to keep their fellow team members up to date with their progress. A good litmus test for this is everyone on the team can describe what their team mates are up to.
 
+### To ensure team ceremonies are held regularly
+
+We expect our engineering team to ensure team ceremonies such as planning, retrospectives, and standups happen on a regular basis.
+
 ### To facilitate showcases and retrospectives
 
 We expect our engineering team to be able to demonstrate the successes of their iterations with weekly showcases to customers. We also expect Engineers to be able to facilitate retrospectives with engaging formats and customer involvement. Good teams will rotate this responsibility on a weekly basis.

--- a/roles/senior_engineer.md
+++ b/roles/senior_engineer.md
@@ -105,6 +105,10 @@ We expect our engineering team to keep their customers up to date with progress.
 
 We expect our engineering team to keep their fellow team members up to date with their progress. A good litmus test for this is everyone on the team can describe what their team mates are up to.
 
+### To ensure team ceremonies are held regularly
+
+We expect our engineering team to ensure team ceremonies such as planning, retrospectives, and standups happen on a regular basis.
+
 ### To facilitate showcases and retrospectives
 
 We expect our engineering team to be able to demonstrate the successes of their iterations with weekly showcases to customers. We also expect Engineers to be able to facilitate retrospectives with engaging formats and customer involvement. Good teams will rotate this responsibility on a weekly basis.


### PR DESCRIPTION
We do this so our engineers are responsible for ensuring ceremonies.