### PR TITLE
Fixed a broken link in remote working.

### DIFF
--- a/benefits/remote_working.md
+++ b/benefits/remote_working.md
@@ -15,7 +15,7 @@ If you have any questions or want to challenge the guidelines below in any way, 
 - Be a good Slack citizen and check in with your team throughout your working day if possible
 - Ensure you're completely clear on your specific workload, down to the task level, for the day or days you wish to work from home, and ensure that you're certain you won't benefit from working closely with others on this
 - Ensure you're not scheduled for any meetings or other sessions
-- Barring any extraordinary circumstances, we like people to be in the office on Friday for [lunch (and hopefully drinks)](/benefits/friday_lunch_drinks.md)
+- Barring any extraordinary circumstances, we like people to be in the office on Friday for [lunch](/benefits/friday_lunch.md) [(and hopefully drinks)](/benefits/friday_drinks.md)
 
 ## Regularly working from home
 


### PR DESCRIPTION
A link in the remote working page was pointed at an old combined file for Friday lunch & drinks.
Split these into two links, pointing at the two separate files for Friday lunch and drinks.