### PR TITLE
Add gravatar to services setup

### DIFF
--- a/company/welcome_pack.md
+++ b/company/welcome_pack.md
@@ -46,7 +46,7 @@ Below is a checklist for you to work with your buddy over the coming weeks.
 #### Non-Engineers
 * [ ] Complete the [Github tutorial](https://guides.github.com/activities/hello-world/)
 
-Below you'll find a list of tools that you will need to do your job. If you haven't already been provided with login credentials, then please let [Rory](rory@madetech.com), [Chris](chris@madetech.com), [Luke](luke@madetech.com) or [Seb](seb@madetech.com) know. 
+Below you'll find a list of tools that you will need to do your job. If you haven't already been provided with login credentials, then please let [Rory](rory@madetech.com), [Chris](chris@madetech.com), [Luke](luke@madetech.com) or [Seb](seb@madetech.com) know.
 
 ### Signing up for Services
 
@@ -66,6 +66,7 @@ Note that Google office applications (Docs, Sheets) are the preferred format for
 * [ ] LastPass (with 2FA)
 * [ ] Trello (with 2FA unless using Google Auth to login to Trello)
 * [ ] Continuous Feedback
+* [ ] Setup an account with [Gravatar](https://en.gravatar.com/) - You can use this to add a shared profile picture for multiple services.
 
 Academy Engineers: you can skip these two for now, but you will probably need them once you graduate.
 


### PR DESCRIPTION
- We use a few things that you can link to gravatar for a shared profile picture (slack, guthub, continuous feedback)