### PR TITLE
Update Lead Engineer role expectations

### DIFF
--- a/roles/as_code/lib/lead_engineer.rb
+++ b/roles/as_code/lib/lead_engineer.rb
@@ -59,19 +59,19 @@ JobSpec::Role.definition 'Lead Engineer' do
 
   salary 50_000..85_000
 
-  expected 'act as a role model and servant leader to the team',
+  expected 'to act as a role model and servant leader to the team',
     'We expect our Lead Engineers to lead by example, to put the needs of others before their own, and to set and demonstrate a high standard for code and delivery quality. A Lead Engineer is expected to show themselves to be highly reliable, to be on time, to be well prepared, and to take ultimate account for ensuring commitments the team has made are kept.'
 
-  expected 'coach and nurture team members to improve their engineering and delivery capability',
+  expected 'to coach and nurture team members to improve their engineering and delivery capability',
     'We expect our Lead Engineers to proactively provide thoughtful and meaningful feedback for their team. A Lead Engineer is expected to spend time helping team members to improve their skills. A Lead Engineer is expected to identify and nurture candidates for Lead and Senior Engineer positions. A Lead Engineer is expected to identify and escalate performance issues to a Director.'
 
-  expected 'lead workshop and roadmapping sessions to understand customer requirements and convert these in to deliverable iterations',
+  expected 'to lead workshop and roadmapping sessions to understand customer requirements and convert these in to deliverable iterations',
     'We expect our Lead Engineers to lead workshop and roadmapping sessions, and foster collaboration with the wider team to identify a technology roadmap to solve business problems.'
 
-  expected 'Quickly become a trusted partner to the customer team, building a friendly relationship',
+  expected 'to quickly become a trusted partner to the customer team, building a friendly relationship',
     'We expect our Lead Engineers to quickly become a trusted partner to the customer team - both our day-to-day contacts, and more senior stakeholders. A Lead Engineer should be able to put a customer at ease by engaging in small talk, and by building strong and friendly working relationships. A Lead Engineer is expected to credibly and knowledgeably represent Made Tech when conversing with senior stakeholders.'
 
-  expected 'Proactively identify opportunities where we can widen the impact of our work with the customer organisation',
+  expected 'to proactively identify opportunities where we can widen the impact of our work with the customer organisation',
     'We expect our Lead Engineers to proactively seek opportunities where we can extend our remit with the customer organisation. A Lead Engineer is expected to understand the objectives of our stakeholders, and to sell Made Tech’s wider capabilities.'
 
   expected 'to make sensible, well reasoned commercial decisions',

--- a/roles/as_code/lib/lead_engineer.rb
+++ b/roles/as_code/lib/lead_engineer.rb
@@ -77,7 +77,6 @@ JobSpec::Role.definition 'Lead Engineer' do
   expected 'to make sensible, well reasoned commercial decisions',
     'We expect our Lead Engineers to proactively make good commercial decisions. A Lead Engineer is expected to identify and course correct potential delivery issues before they become impactful. A Lead Engineer is expected to proactively escalate larger delivery issues to the Delivery Manager or Delivery Director.'
 
-  include DeliveryLeadExpectations, as: 'Delivery Lead Expectations'
   include SeniorEngineerExpectations, as: 'Senior Engineer Expectations'
   include CoreEngineerExpectations, as: 'Core Engineer Expectations'
 end

--- a/roles/lead_engineer.md
+++ b/roles/lead_engineer.md
@@ -55,23 +55,23 @@ This role has a salary of £50-85k depending on experience.
 
 ## Expectations
 
-### Act as a role model and servant leader to the team
+### To act as a role model and servant leader to the team
 
 We expect our Lead Engineers to lead by example, to put the needs of others before their own, and to set and demonstrate a high standard for code and delivery quality. A Lead Engineer is expected to show themselves to be highly reliable, to be on time, to be well prepared, and to take ultimate account for ensuring commitments the team has made are kept.
 
-### Coach and nurture team members to improve their engineering and delivery capability
+### To coach and nurture team members to improve their engineering and delivery capability
 
 We expect our Lead Engineers to proactively provide thoughtful and meaningful feedback for their team. A Lead Engineer is expected to spend time helping team members to improve their skills. A Lead Engineer is expected to identify and nurture candidates for Lead and Senior Engineer positions. A Lead Engineer is expected to identify and escalate performance issues to a Director.
 
-### Lead workshop and roadmapping sessions to understand customer requirements and convert these in to deliverable iterations
+### To lead workshop and roadmapping sessions to understand customer requirements and convert these in to deliverable iterations
 
 We expect our Lead Engineers to lead workshop and roadmapping sessions, and foster collaboration with the wider team to identify a technology roadmap to solve business problems.
 
-### Quickly become a trusted partner to the customer team, building a friendly relationship
+### To quickly become a trusted partner to the customer team, building a friendly relationship
 
 We expect our Lead Engineers to quickly become a trusted partner to the customer team - both our day-to-day contacts, and more senior stakeholders. A Lead Engineer should be able to put a customer at ease by engaging in small talk, and by building strong and friendly working relationships. A Lead Engineer is expected to credibly and knowledgeably represent Made Tech when conversing with senior stakeholders.
 
-### Proactively identify opportunities where we can widen the impact of our work with the customer organisation
+### To proactively identify opportunities where we can widen the impact of our work with the customer organisation
 
 We expect our Lead Engineers to proactively seek opportunities where we can extend our remit with the customer organisation. A Lead Engineer is expected to understand the objectives of our stakeholders, and to sell Made Tech’s wider capabilities.
 

--- a/roles/lead_engineer.md
+++ b/roles/lead_engineer.md
@@ -79,44 +79,6 @@ We expect our Lead Engineers to proactively seek opportunities where we can exte
 
 We expect our Lead Engineers to proactively make good commercial decisions. A Lead Engineer is expected to identify and course correct potential delivery issues before they become impactful. A Lead Engineer is expected to proactively escalate larger delivery issues to the Delivery Manager or Delivery Director.
 
-## Delivery Lead Expectations
-
-### Be the point of contact for the customer
-
-We expect our Delivery Leads to naturally position themselves as the day to day point of contact for the customer. A Delivery Lead is expected to gain the trust of the customer such that they’re seen as the first port of call for all customer contacts.
-
-### Ensure customer expectations are exceeded given the budget available
-
-We expect our Delivery Leads to understand the financial constraints, as well as the customer objectives for the delivery. A Delivery Lead is accountable for ensuring the customer’s expectations are exceeded for the available budget.
-
-### Ultimately accountable for the successful delivery of customer engagements
-
-We expect our Delivery Leads to assume ultimate responsibility for the successful delivery of customer engagements. The performance of the team and the delivery as a whole is understood as the Delivery Lead’s responsibility.
-
-### Provide accurate and honest reporting of Delivery Healthcheck to Directors
-
-We expect our Delivery Leads to proactively provide regular reporting to the Directors on the health of their delivery.
-
-### Ensure that at all times the team is delivering according to the Made Tech Delivery Standards
-
-We expect our Delivery Leads to be the guardians of the Made Tech Delivery Standards, ensuring the team understands and is proactively practising them. A Delivery Lead is expected to encourage conversation on both more widely evolving the Delivery Standards, and ahead of deciding to follow a different path on their delivery.
-
-### Ensure that the customer becomes a long-term advocate for Made Tech
-
-We expect our Delivery Leads to take accountability for ensuring the customer is delighted with the quality of our delivery to the level that they would not hesitate to recommend Made Tech to their peers.
-
-### Protect the team from influences that may impact their ability to deliver
-
-We expect our Delivery Leads to demonstrate strong diplomacy when protecting their team from influences that may impact the team’s ability to deliver its objectives and commitments.
-
-### Ensure the team collaborates, communicates and focuses on what is most important
-
-We expect our Delivery Leads to ensure the team is actively collaborating and communicating, both between team members and with the customer. A Delivery Lead is expected to ensure the team have a shared understanding of what is most important to the customer.
-
-### Coach team members and customers, facilitate continuous improvement, and apply the most appropriate agile and lean tools and techniques for their environment
-
-We expect our Delivery Leads to be an expert in the application of agile and lean practices. A Delivery Lead is expected to understand the most appropriate methods to apply given the situation. A Delivery Lead is expected to coach team members and customers on the application of lean and agile practices.
-
 ## Senior Engineer Expectations
 
 ### To make sensible and well justified technical architecture decisions, involving the team in the decision making process where appropriate


### PR DESCRIPTION
We remove Delivery Lead expectations from Lead Engineer role as Delivery Managers by default will assume this role on delivery teams.

Also make some minor wording amendments to remaining expectations to be consistent.

All Lead Engineers will need to update their role expectations spreadsheets to remove Delivery Lead expectations and also ensure Senior expectations are listed.