### PR TITLE
Update Reliability Engineer role expectations

### DIFF
--- a/roles/as_code/lib/reliability_engineer.rb
+++ b/roles/as_code/lib/reliability_engineer.rb
@@ -60,13 +60,13 @@ JobSpec::Role.definition 'Reliability Engineer' do
   salary 40_000..75_000
 
   expected 'to proactively identify technical improvements and recommend them to delivery teams',
-  'We expect our Reliability Engineers to be able to spot areas for improvement in customer codebases such as test suites, dependency upgrades, performance issues detected by monitoring. We also expect them to be able to highlight these issues in a jargon free way and be able to convey the relative urgency of the issues ultimately leading to our customer codebases being improved.'
+    'We expect our Reliability Engineers to be able to spot areas for improvement in codebases such as test suites, dependency upgrades, performance issues detected by monitoring. We also expect them to be able to highlight these issues in a jargon free way and be able to convey the relative urgency of the issues ultimately leading to codebases being improved.'
 
   expected 'to autonomously deliver working software',
     'We expect our Reliability Engineers to be able to work on entire features, from conception through to production deployment, without guidance and direction from others. This doesn\'t mean they have to be delivered without pairing, or asking advice from the wider team. What it does mean is the primary force for ensuring the feature is built and deployed in a timely fashion is the responsiblity of the Reliability Engineer working on the problem.'
 
   expected 'to be fully billable by timesheeting 7 hours daily',
-    'We expect our Reliability Engineers to ensure they are timesheeting 7 hours daily into harvest. As our current offering means we offer hours to our customers we need to make sure we are working through these hours and providing value to our customers.'
+    'We expect our Reliability Engineers to ensure they are timesheeting 7 hours daily into harvest. As our Reliability Engineers rotate around teams we need to ensure we remain profitable.'
 
   expected 'to be a responsible remote worker',
     'We expect our Reliability Engineers team to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels such as email and Slack.'

--- a/roles/as_code/lib/reliability_engineer.rb
+++ b/roles/as_code/lib/reliability_engineer.rb
@@ -69,7 +69,7 @@ JobSpec::Role.definition 'Reliability Engineer' do
     'We expect our Reliability Engineers to be able to work on entire features, from conception through to production deployment, without guidance and direction from others. This doesn\'t mean they have to be delivered without pairing, or asking advice from the wider team. What it does mean is the primary force for ensuring the feature is built and deployed in a timely fashion is the responsiblity of the Reliability Engineer working on the problem.'
 
   expected 'to be fully billable by timesheeting 7 hours daily',
-    'We expect our Reliability Engineers to ensure they are timesheeting 7 hours daily into harvest. As our Reliability Engineers rotate around teams we need to ensure we remain profitable.'
+    'We expect our Reliability Engineers to ensure they are timesheeting 7 hours daily, 4 days a week. As our Reliability Engineers rotate around teams we need to ensure we remain profitable.'
 
   expected 'to be a responsible remote worker',
     'We expect our Reliability Engineers team to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels such as email and Slack.'

--- a/roles/as_code/lib/reliability_engineer.rb
+++ b/roles/as_code/lib/reliability_engineer.rb
@@ -72,10 +72,10 @@ JobSpec::Role.definition 'Reliability Engineer' do
     'We expect our Reliability Engineers to ensure they are timesheeting 7 hours daily, 4 days a week. As our Reliability Engineers rotate around teams we need to ensure we remain profitable.'
 
   expected 'to be a responsible remote worker',
-    'We expect our Reliability Engineers team to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels such as email and Slack.'
+    'We expect our Reliability Engineers to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels such as email and Slack.'
 
   expected 'to effectively juggle commitments',
-    'We expect our Reliability Engineers team to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Commitments need to be set and met. If they cannot be met they should be reset early and often.'
+    'We expect our Reliability Engineers to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Commitments need to be set and met. If they cannot be met they should be reset early and often.'
 
   include CoreEngineerExpectations, as: 'Core Engineer Expectations'
 end

--- a/roles/as_code/lib/reliability_engineer.rb
+++ b/roles/as_code/lib/reliability_engineer.rb
@@ -59,6 +59,9 @@ JobSpec::Role.definition 'Reliability Engineer' do
 
   salary 40_000..75_000
 
+  expected 'to be ambassadors of reliability engineering culture',
+    'We expect our Reliability Engineers to contribute to our reliability engineering culture, standards and thought leadership. We expect Reliability Engineers to champion existing standards by working closely with delivery teams to coach and mentor them. We also expect all Reliability Engineers to be involved in discussions around improving our standards.'
+
   expected 'to proactively identify technical improvements and recommend them to delivery teams',
     'We expect our Reliability Engineers to be able to spot areas for improvement in codebases such as test suites, dependency upgrades, performance issues detected by monitoring. We also expect them to be able to highlight these issues in a jargon free way and be able to convey the relative urgency of the issues ultimately leading to codebases being improved.'
 

--- a/roles/as_code/lib/reliability_engineer.rb
+++ b/roles/as_code/lib/reliability_engineer.rb
@@ -66,7 +66,7 @@ JobSpec::Role.definition 'Reliability Engineer' do
     'We expect our Reliability Engineers to be able to spot areas for improvement in codebases such as test suites, dependency upgrades, performance issues detected by monitoring. We also expect them to be able to highlight these issues in a jargon free way and be able to convey the relative urgency of the issues ultimately leading to codebases being improved.'
 
   expected 'to autonomously deliver working software',
-    'We expect our Reliability Engineers to be able to work on entire features, from conception through to production deployment, without guidance and direction from others. This doesn\'t mean they have to be delivered without pairing, or asking advice from the wider team. What it does mean is the primary force for ensuring the feature is built and deployed in a timely fashion is the responsiblity of the Reliability Engineer working on the problem.'
+    'We expect our Reliability Engineers to be able to work on entire changesets, from conception through to production deployment, without guidance and direction from others. This doesn\'t mean they have to be delivered without pairing, or asking advice from the wider team. What it does mean is the primary force for ensuring the changeset is built and deployed in a timely fashion is the responsiblity of the Reliability Engineer working on the problem.'
 
   expected 'to be fully billable by timesheeting 7 hours daily',
     'We expect our Reliability Engineers to ensure they are timesheeting 7 hours daily, 4 days a week. As our Reliability Engineers rotate around teams we need to ensure we remain profitable.'
@@ -75,7 +75,7 @@ JobSpec::Role.definition 'Reliability Engineer' do
     'We expect our Reliability Engineers team to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels such as email and Slack.'
 
   expected 'to effectively juggle commitments',
-    'We expect our Reliability Engineers team to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Customer expectations need to be set and met. If they cannot be met they should be reset early and often.'
+    'We expect our Reliability Engineers team to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Commitments need to be set and met. If they cannot be met they should be reset early and often.'
 
   include CoreEngineerExpectations, as: 'Core Engineer Expectations'
 end

--- a/roles/as_code/lib/reliability_engineer.rb
+++ b/roles/as_code/lib/reliability_engineer.rb
@@ -59,15 +59,20 @@ JobSpec::Role.definition 'Reliability Engineer' do
 
   salary 40_000..75_000
 
+  expected 'to proactively identify technical improvements and recommend them to delivery teams',
+  'We expect our Reliability Engineers to be able to spot areas for improvement in customer codebases such as test suites, dependency upgrades, performance issues detected by monitoring. We also expect them to be able to highlight these issues in a jargon free way and be able to convey the relative urgency of the issues ultimately leading to our customer codebases being improved.'
+
   expected 'to autonomously deliver working software',
     'We expect our Reliability Engineers to be able to work on entire features, from conception through to production deployment, without guidance and direction from others. This doesn\'t mean they have to be delivered without pairing, or asking advice from the wider team. What it does mean is the primary force for ensuring the feature is built and deployed in a timely fashion is the responsiblity of the Reliability Engineer working on the problem.'
 
   expected 'to be fully billable by timesheeting 7 hours daily',
     'We expect our Reliability Engineers to ensure they are timesheeting 7 hours daily into harvest. As our current offering means we offer hours to our customers we need to make sure we are working through these hours and providing value to our customers.'
 
-  expected 'to proactively identify technical improvements and recommend them to customers',
-    'We expect our Reliability Engineers to be able to spot areas for improvement in customer codebases such as test suites, dependency upgrades, performance issues detected by monitoring. We also expect them to be able to highlight these issues in a jargon free way and be able to convey the relative urgency of the issues ultimately leading to our customer codebases being improved.'
+  expected 'to be a responsible remote worker',
+    'We expect our Reliability Engineers team to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels such as email and Slack.'
 
-  include LiveServicesExpectations, as: 'Live Services Expectations'
+  expected 'to effectively juggle commitments',
+    'We expect our Reliability Engineers team to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Customer expectations need to be set and met. If they cannot be met they should be reset early and often.'
+
   include CoreEngineerExpectations, as: 'Core Engineer Expectations'
 end

--- a/roles/as_code/lib/reliability_engineer.rb
+++ b/roles/as_code/lib/reliability_engineer.rb
@@ -9,9 +9,7 @@ JobSpec::Role.definition 'Reliability Engineer' do
 
     We primarily write and deliver custom software to our customers. We build solutions in a variety of languages and platforms, historically Ruby on Rails, we tend to use React, JavaScript, Elixir, and Clojure these days. We will usually be responsible for setting up a customer’s infrastructure on AWS with tools like Ansible and Terraform though sometimes we opt for a Platform as a Service like Heroku. We make sure there is a Continuous Delivery pipeline running our automated test suites before deploying changes.
 
-    Our application and infrastructure lifetime support services are an important part of our business. Often once our delivery teams have built custom software, the applications and infrastructure will be on boarded into our lifetime support team. This team is responsible for the ongoing development of applications, adapting applications to changing requirements as our customers grow, and fixing problems as they arise. We also onboard some applications that our teams haven’t built if they pass our quality and maintainability audits.
-
-    Reliability Engineers will split their time between responding to automated alerts, proactive codebase improvement, answering requests sent into our customer support desk, and ongoing feature development.
+    Reliability Engineers will split their time between responding to automated alerts ensuring the uptime of our customers applications, proactive codebase improvements, coaching and mentoring delivery teams to build production-ready systems and championing reliability engineering culture more widely.
 
     This role requires less of a physical presence with customers and therefore it is our first fully remote engineering role. You are of course welcome to work from our offices rather than remote but the option is open. As previously mentioned, regular communication with customers is still a must.
 

--- a/roles/reliability_engineer.md
+++ b/roles/reliability_engineer.md
@@ -58,7 +58,7 @@ This role has a salary of £40-75k depending on experience.
 
 ### To proactively identify technical improvements and recommend them to delivery teams
 
-We expect our Reliability Engineers to be able to spot areas for improvement in customer codebases such as test suites, dependency upgrades, performance issues detected by monitoring. We also expect them to be able to highlight these issues in a jargon free way and be able to convey the relative urgency of the issues ultimately leading to our customer codebases being improved.
+We expect our Reliability Engineers to be able to spot areas for improvement in codebases such as test suites, dependency upgrades, performance issues detected by monitoring. We also expect them to be able to highlight these issues in a jargon free way and be able to convey the relative urgency of the issues ultimately leading to codebases being improved.
 
 ### To autonomously deliver working software
 
@@ -66,7 +66,7 @@ We expect our Reliability Engineers to be able to work on entire features, from 
 
 ### To be fully billable by timesheeting 7 hours daily
 
-We expect our Reliability Engineers to ensure they are timesheeting 7 hours daily into harvest. As our current offering means we offer hours to our customers we need to make sure we are working through these hours and providing value to our customers.
+We expect our Reliability Engineers to ensure they are timesheeting 7 hours daily into harvest. As our Reliability Engineers rotate around teams we need to ensure we remain profitable.
 
 ### To be a responsible remote worker
 

--- a/roles/reliability_engineer.md
+++ b/roles/reliability_engineer.md
@@ -6,9 +6,7 @@ Our Reliability Engineers evolve and maintain applications and infrastructure fo
 
 We primarily write and deliver custom software to our customers. We build solutions in a variety of languages and platforms, historically Ruby on Rails, we tend to use React, JavaScript, Elixir, and Clojure these days. We will usually be responsible for setting up a customer’s infrastructure on AWS with tools like Ansible and Terraform though sometimes we opt for a Platform as a Service like Heroku. We make sure there is a Continuous Delivery pipeline running our automated test suites before deploying changes.
 
-Our application and infrastructure lifetime support services are an important part of our business. Often once our delivery teams have built custom software, the applications and infrastructure will be on boarded into our lifetime support team. This team is responsible for the ongoing development of applications, adapting applications to changing requirements as our customers grow, and fixing problems as they arise. We also onboard some applications that our teams haven’t built if they pass our quality and maintainability audits.
-
-Reliability Engineers will split their time between responding to automated alerts, proactive codebase improvement, answering requests sent into our customer support desk, and ongoing feature development.
+Reliability Engineers will split their time between responding to automated alerts ensuring the uptime of our customers applications, proactive codebase improvements, coaching and mentoring delivery teams to build production-ready systems and championing reliability engineering culture more widely.
 
 This role requires less of a physical presence with customers and therefore it is our first fully remote engineering role. You are of course welcome to work from our offices rather than remote but the option is open. As previously mentioned, regular communication with customers is still a must.
 

--- a/roles/reliability_engineer.md
+++ b/roles/reliability_engineer.md
@@ -66,7 +66,7 @@ We expect our Reliability Engineers to be able to spot areas for improvement in 
 
 ### To autonomously deliver working software
 
-We expect our Reliability Engineers to be able to work on entire features, from conception through to production deployment, without guidance and direction from others. This doesn't mean they have to be delivered without pairing, or asking advice from the wider team. What it does mean is the primary force for ensuring the feature is built and deployed in a timely fashion is the responsiblity of the Reliability Engineer working on the problem.
+We expect our Reliability Engineers to be able to work on entire changesets, from conception through to production deployment, without guidance and direction from others. This doesn't mean they have to be delivered without pairing, or asking advice from the wider team. What it does mean is the primary force for ensuring the changeset is built and deployed in a timely fashion is the responsiblity of the Reliability Engineer working on the problem.
 
 ### To be fully billable by timesheeting 7 hours daily
 
@@ -78,7 +78,7 @@ We expect our Reliability Engineers team to communicate more than anyone else in
 
 ### To effectively juggle commitments
 
-We expect our Reliability Engineers team to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Customer expectations need to be set and met. If they cannot be met they should be reset early and often.
+We expect our Reliability Engineers team to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Commitments need to be set and met. If they cannot be met they should be reset early and often.
 
 ## Core Engineer Expectations
 

--- a/roles/reliability_engineer.md
+++ b/roles/reliability_engineer.md
@@ -74,11 +74,11 @@ We expect our Reliability Engineers to ensure they are timesheeting 7 hours dail
 
 ### To be a responsible remote worker
 
-We expect our Reliability Engineers team to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels such as email and Slack.
+We expect our Reliability Engineers to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels such as email and Slack.
 
 ### To effectively juggle commitments
 
-We expect our Reliability Engineers team to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Commitments need to be set and met. If they cannot be met they should be reset early and often.
+We expect our Reliability Engineers to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Commitments need to be set and met. If they cannot be met they should be reset early and often.
 
 ## Core Engineer Expectations
 

--- a/roles/reliability_engineer.md
+++ b/roles/reliability_engineer.md
@@ -70,7 +70,7 @@ We expect our Reliability Engineers to be able to work on entire features, from 
 
 ### To be fully billable by timesheeting 7 hours daily
 
-We expect our Reliability Engineers to ensure they are timesheeting 7 hours daily into harvest. As our Reliability Engineers rotate around teams we need to ensure we remain profitable.
+We expect our Reliability Engineers to ensure they are timesheeting 7 hours daily, 4 days a week. As our Reliability Engineers rotate around teams we need to ensure we remain profitable.
 
 ### To be a responsible remote worker
 

--- a/roles/reliability_engineer.md
+++ b/roles/reliability_engineer.md
@@ -56,6 +56,10 @@ This role has a salary of £40-75k depending on experience.
 
 ## Expectations
 
+### To be ambassadors of reliability engineering culture
+
+We expect our Reliability Engineers to contribute to our reliability engineering culture, standards and thought leadership. We expect Reliability Engineers to champion existing standards by working closely with delivery teams to coach and mentor them. We also expect all Reliability Engineers to be involved in discussions around improving our standards.
+
 ### To proactively identify technical improvements and recommend them to delivery teams
 
 We expect our Reliability Engineers to be able to spot areas for improvement in codebases such as test suites, dependency upgrades, performance issues detected by monitoring. We also expect them to be able to highlight these issues in a jargon free way and be able to convey the relative urgency of the issues ultimately leading to codebases being improved.

--- a/roles/reliability_engineer.md
+++ b/roles/reliability_engineer.md
@@ -56,6 +56,10 @@ This role has a salary of £40-75k depending on experience.
 
 ## Expectations
 
+### To proactively identify technical improvements and recommend them to delivery teams
+
+We expect our Reliability Engineers to be able to spot areas for improvement in customer codebases such as test suites, dependency upgrades, performance issues detected by monitoring. We also expect them to be able to highlight these issues in a jargon free way and be able to convey the relative urgency of the issues ultimately leading to our customer codebases being improved.
+
 ### To autonomously deliver working software
 
 We expect our Reliability Engineers to be able to work on entire features, from conception through to production deployment, without guidance and direction from others. This doesn't mean they have to be delivered without pairing, or asking advice from the wider team. What it does mean is the primary force for ensuring the feature is built and deployed in a timely fashion is the responsiblity of the Reliability Engineer working on the problem.
@@ -64,23 +68,13 @@ We expect our Reliability Engineers to be able to work on entire features, from 
 
 We expect our Reliability Engineers to ensure they are timesheeting 7 hours daily into harvest. As our current offering means we offer hours to our customers we need to make sure we are working through these hours and providing value to our customers.
 
-### To proactively identify technical improvements and recommend them to customers
-
-We expect our Reliability Engineers to be able to spot areas for improvement in customer codebases such as test suites, dependency upgrades, performance issues detected by monitoring. We also expect them to be able to highlight these issues in a jargon free way and be able to convey the relative urgency of the issues ultimately leading to our customer codebases being improved.
-
-## Live Services Expectations
-
-### To provide an outstanding customer service
-
-We expect our Live Services team to be delightful to interact with. Our conversations should be professional and friendly, we should small talk where possible, use a smiley face once in a while and generally be nice folk.
-
 ### To be a responsible remote worker
 
-We expect our Live Services team to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels such as email and Slack.
+We expect our Reliability Engineers team to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels such as email and Slack.
 
 ### To effectively juggle commitments
 
-We expect our Live Services team to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Customer expectations need to be set and met. If they cannot be met they should be reset early and often.
+We expect our Reliability Engineers team to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Customer expectations need to be set and met. If they cannot be met they should be reset early and often.
 
 ## Core Engineer Expectations
 


### PR DESCRIPTION
We update RE role to account for recent changes:

 - We update JD to no longer include description of Live Services and also add more responsibility around coaching and championing.
 - Remove LiveServiceExpectations mixin from Reliability Engineer
 - Remove “customers” from expectations as it’s more about REs servicing delivery teams
 - Add additional expectation around being ambassadors for our reliability engineering culture

We will need to update Reliability Engineer role expectation spreadsheets.