### PR TITLE
Add Senior Reliability Engineer role

### DIFF
--- a/roles/as_code/lib/reliability_engineer.rb
+++ b/roles/as_code/lib/reliability_engineer.rb
@@ -54,10 +54,10 @@ JobSpec::Role.definition 'Reliability Engineer' do
 
     ## Salary
 
-    This role has a salary of £40-75k depending on experience.
+    This role has a salary of £40-60k depending on experience.
   DESCRIPTION
 
-  salary 40_000..75_000
+  salary 40_000..60_000
 
   include ReliabilityEngineerExpectations, as: 'Reliability Engineer Expectations'
   include CoreEngineerExpectations, as: 'Core Engineer Expectations'

--- a/roles/as_code/lib/reliability_engineer.rb
+++ b/roles/as_code/lib/reliability_engineer.rb
@@ -1,5 +1,5 @@
 require_relative './shared_expectations/core_engineer_expectations'
-require_relative './shared_expectations/live_services_expectations'
+require_relative './shared_expectations/reliability_engineer_expectations'
 
 JobSpec::Role.definition 'Reliability Engineer' do
   description <<~DESCRIPTION
@@ -59,23 +59,6 @@ JobSpec::Role.definition 'Reliability Engineer' do
 
   salary 40_000..75_000
 
-  expected 'to be ambassadors of reliability engineering culture',
-    'We expect our Reliability Engineers to contribute to our reliability engineering culture, standards and thought leadership. We expect Reliability Engineers to champion existing standards by working closely with delivery teams to coach and mentor them. We also expect all Reliability Engineers to be involved in discussions around improving our standards.'
-
-  expected 'to proactively identify technical improvements and recommend them to delivery teams',
-    'We expect our Reliability Engineers to be able to spot areas for improvement in codebases such as test suites, dependency upgrades, performance issues detected by monitoring. We also expect them to be able to highlight these issues in a jargon free way and be able to convey the relative urgency of the issues ultimately leading to codebases being improved.'
-
-  expected 'to autonomously deliver working software',
-    'We expect our Reliability Engineers to be able to work on entire changesets, from conception through to production deployment, without guidance and direction from others. This doesn\'t mean they have to be delivered without pairing, or asking advice from the wider team. What it does mean is the primary force for ensuring the changeset is built and deployed in a timely fashion is the responsiblity of the Reliability Engineer working on the problem.'
-
-  expected 'to be fully billable by timesheeting 7 hours daily',
-    'We expect our Reliability Engineers to ensure they are timesheeting 7 hours daily, 4 days a week. As our Reliability Engineers rotate around teams we need to ensure we remain profitable.'
-
-  expected 'to be a responsible remote worker',
-    'We expect our Reliability Engineers to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels such as email and Slack.'
-
-  expected 'to effectively juggle commitments',
-    'We expect our Reliability Engineers to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Commitments need to be set and met. If they cannot be met they should be reset early and often.'
-
+  include ReliabilityEngineerExpectations, as: 'Reliability Engineer Expectations'
   include CoreEngineerExpectations, as: 'Core Engineer Expectations'
 end

--- a/roles/as_code/lib/senior_reliability_engineer.rb
+++ b/roles/as_code/lib/senior_reliability_engineer.rb
@@ -4,7 +4,7 @@ require_relative './shared_expectations/reliability_engineer_expectations'
 
 JobSpec::Role.definition 'Senior Reliability Engineer' do
   description <<~DESCRIPTION
-    Our Senior Reliability Engineers evolve and maintain applications and infrastructure for our customers. Scalability and proactive improvements are the focus and good communication skills – the necessity.
+    Our Senior Reliability Engineers are champions of the Made Tech reliability engineering culture and devops in it's truest and most collaborative form. Through coaching and mentoring our reliability engineering team as well as remaining hands-on, our Senior Reliability Engineers ensure the quality of our customers applications through their lifetime.
 
     ## What does the job entail?
 
@@ -43,7 +43,7 @@ JobSpec::Role.definition 'Senior Reliability Engineer' do
 
     We are a sanctuary for those wanting to hone their skills alongside like-minded learners. After joining our team it is common for new starters to comment on how much they’re learning and how much they enjoy the fact they are surrounded by people they can learn from. This includes our most senior hires.
 
-    The biggest thing you’ll take away from our culture after spending the day with us would be that we practice continuous improvement at every level. Everyone has peer-based one-to-ones every 2 weeks, along with monthly one-to-ones with a director. Teams have fortnightly retrospectives. We also hold a company wide retrospective fortnightly. We discuss our problems out in the open, and rather than punish failure we band together to find solutions.
+    The biggest thing you’ll take away from our culture after spending the day with us would be that we practice continuous improvement at every level. Everyone has peer-based one-to-ones every 2 weeks, along with monthly one-to-ones with a Line Manager. Teams have fortnightly retrospectives. We also hold a company wide retrospective fortnightly. We discuss our problems out in the open, and rather than punish failure we band together to find solutions.
 
     Other notable things:
 

--- a/roles/as_code/lib/senior_reliability_engineer.rb
+++ b/roles/as_code/lib/senior_reliability_engineer.rb
@@ -60,6 +60,12 @@ JobSpec::Role.definition 'Senior Reliability Engineer' do
 
   salary 60_000..75_000
 
+  expected 'to drive the reliability engineering agenda across Made Tech',
+    'We expect the Senior Reliability Engineers to drive the reliability engineering agenda across the business. They should set the standard for what "good" looks like for applications from a maintainability, scalability, and security perspective, and ensure delivery teams understand are bought in to these standards.'
+
+  expected 'to coach and nurture team members to improve their reliability engineering capability',
+    'We expect our Senior Reliability Engineers to proactively provide thoughtful and meaningful feedback for their team. A Senior Reliability Engineer is expected to spend time helping team members to improve their skills. A Senior Reliability Engineer is expected to identify and nurture candidates for Senior Reliability Engineer positions.'
+
   include ReliabilityEngineerExpectations, as: 'Reliability Engineer Expectations'
   include SeniorEngineerExpectations, as: 'Senior Engineer Expectations'
   include CoreEngineerExpectations, as: 'Core Engineer Expectations'

--- a/roles/as_code/lib/senior_reliability_engineer.rb
+++ b/roles/as_code/lib/senior_reliability_engineer.rb
@@ -10,7 +10,9 @@ JobSpec::Role.definition 'Senior Reliability Engineer' do
 
     We primarily write and deliver custom software to our customers. We build solutions in a variety of languages and platforms, historically Ruby on Rails, we tend to use React, JavaScript, Elixir, and Clojure these days. We will usually be responsible for setting up a customer’s infrastructure on AWS with tools like Ansible and Terraform though sometimes we opt for a Platform as a Service like Heroku. We make sure there is a Continuous Delivery pipeline running our automated test suites before deploying changes.
 
-    Reliability Engineers will split their time between responding to automated alerts ensuring the uptime of applications, proactive codebase improvements, coaching and mentoring delivery teams to build production-ready systems and championing reliability engineering culture more widely. Reliability Engineers serve our delivery teams who ultimately serve our customers.
+    Senior Reliability Engineers will split their time between responding to automated alerts ensuring the uptime of applications, proactive codebase improvements, coaching and mentoring delivery teams to build production-ready systems and championing reliability engineering culture more widely. Senior Reliability Engineers serve our delivery teams who ultimately serve our customers.
+
+    Senior Reliability Engineers are also responsible for coaching and mentoring other members of the reliability engineering team as well as championing reliability engineering culture more widely.
 
     This role requires less of a physical presence with delivery teams and therefore it is our first fully remote engineering role. You are of course welcome to work from our offices rather than remote but the option is open. Being remote means regular communication and being visible is important.
 

--- a/roles/as_code/lib/senior_reliability_engineer.rb
+++ b/roles/as_code/lib/senior_reliability_engineer.rb
@@ -1,0 +1,66 @@
+require_relative './shared_expectations/core_engineer_expectations'
+require_relative './shared_expectations/senior_engineer_expectations'
+require_relative './shared_expectations/reliability_engineer_expectations'
+
+JobSpec::Role.definition 'Senior Reliability Engineer' do
+  description <<~DESCRIPTION
+    Our Senior Reliability Engineers evolve and maintain applications and infrastructure for our customers. Scalability and proactive improvements are the focus and good communication skills – the necessity.
+
+    ## What does the job entail?
+
+    We primarily write and deliver custom software to our customers. We build solutions in a variety of languages and platforms, historically Ruby on Rails, we tend to use React, JavaScript, Elixir, and Clojure these days. We will usually be responsible for setting up a customer’s infrastructure on AWS with tools like Ansible and Terraform though sometimes we opt for a Platform as a Service like Heroku. We make sure there is a Continuous Delivery pipeline running our automated test suites before deploying changes.
+
+    Reliability Engineers will split their time between responding to automated alerts ensuring the uptime of our customers applications, proactive codebase improvements, coaching and mentoring delivery teams to build production-ready systems and championing reliability engineering culture more widely.
+
+    This role requires less of a physical presence with customers and therefore it is our first fully remote engineering role. You are of course welcome to work from our offices rather than remote but the option is open. As previously mentioned, regular communication with customers is still a must.
+
+    ## What experience are we looking for?
+
+    We’ll expect you to be a polyglot programmer versed in a mix of object and functional programming languages. We expect you to be able to jump into a project in a language, framework or configuration you’ve not worked in before and be able to fix issues, improve the codebase and build new features in it. Not only this but the right person would be adept in sharing their knowledge with others – we’d love to hear some examples of coaching and growing team members.
+
+    Multitasking, or more accurately, prioritisation is a big part of being a Reliability Engineer. We expect you to be able to prioritise your work, be able to switch onto resolving emergencies without being told to, and keep all customers up to date.
+
+    Code is only the half of it. The other half is communication. We expect you to be a great communicator with customers and colleagues in written and spoken English. Reliability Engineers keep in touch with customers mostly via Slack and Google Hangouts.
+
+    Further required experience:
+
+    - Debugging a range of applications
+    - Experience debugging infrastructure (AWS/Heroku/Linux/HTTP)
+    - Working directly with customers
+    - Writing code with Test Driven Development
+    - Pair programming as we pair around 50% of the time
+    - Agile practices such as Scrum, XP, and/or Kanban
+    - Working with a range of SQL and NoSQL databases
+    - Infrastructure as code tools such as Ansible, Chef, Puppet, and/or Saltstack
+
+    Everything else is optional but highly sought after. We would love you to have experience in:
+
+    - Writing code with Acceptance Test Driven Development
+    - Component based design techniques such as using pattern libraries, styled components, CSS-in-JS, BEM, and/or SUIT CSS
+    - The React ecosystem including a TDD approach
+
+    ## What is it like to work at Made Tech?
+
+    We are a sanctuary for those wanting to hone their skills alongside like-minded learners. After joining our team it is common for new starters to comment on how much they’re learning and how much they enjoy the fact they are surrounded by people they can learn from. This includes our most senior hires.
+
+    The biggest thing you’ll take away from our culture after spending the day with us would be that we practice continuous improvement at every level. Everyone has peer-based one-to-ones every 2 weeks, along with monthly one-to-ones with a director. Teams have fortnightly retrospectives. We also hold a company wide retrospective fortnightly. We discuss our problems out in the open, and rather than punish failure we band together to find solutions.
+
+    Other notable things:
+
+    - Every Friday afternoon is dedicated to learning new skills
+    - Everyone is encouraged to write blog posts regularly
+    - Our handbook is open sourced
+    - We are vegan and non-drinker friendly as well as meat-eater and drinker friendly
+    - Retreats and trips every year
+
+    ## Salary
+
+    This role has a salary of £60-75k depending on experience.
+  DESCRIPTION
+
+  salary 60_000..75_000
+
+  include ReliabilityEngineerExpectations, as: 'Reliability Engineer Expectations'
+  include SeniorEngineerExpectations, as: 'Senior Engineer Expectations'
+  include CoreEngineerExpectations, as: 'Core Engineer Expectations'
+end

--- a/roles/as_code/lib/senior_reliability_engineer.rb
+++ b/roles/as_code/lib/senior_reliability_engineer.rb
@@ -4,29 +4,28 @@ require_relative './shared_expectations/reliability_engineer_expectations'
 
 JobSpec::Role.definition 'Senior Reliability Engineer' do
   description <<~DESCRIPTION
-    Our Senior Reliability Engineers are champions of the Made Tech reliability engineering culture and devops in it's truest and most collaborative form. Through coaching and mentoring our reliability engineering team as well as remaining hands-on, our Senior Reliability Engineers ensure the quality of our customers applications through their lifetime.
+    Our Senior Reliability Engineers are champions of the Made Tech reliability engineering culture and DevOps in it's truest and most collaborative form. Through coaching and mentoring our reliability engineering team as well as remaining hands-on, our Senior Reliability Engineers ensure the quality of applications through their lifetime.
 
     ## What does the job entail?
 
     We primarily write and deliver custom software to our customers. We build solutions in a variety of languages and platforms, historically Ruby on Rails, we tend to use React, JavaScript, Elixir, and Clojure these days. We will usually be responsible for setting up a customer’s infrastructure on AWS with tools like Ansible and Terraform though sometimes we opt for a Platform as a Service like Heroku. We make sure there is a Continuous Delivery pipeline running our automated test suites before deploying changes.
 
-    Reliability Engineers will split their time between responding to automated alerts ensuring the uptime of our customers applications, proactive codebase improvements, coaching and mentoring delivery teams to build production-ready systems and championing reliability engineering culture more widely.
+    Reliability Engineers will split their time between responding to automated alerts ensuring the uptime of applications, proactive codebase improvements, coaching and mentoring delivery teams to build production-ready systems and championing reliability engineering culture more widely. Reliability Engineers serve our delivery teams who ultimately serve our customers.
 
-    This role requires less of a physical presence with customers and therefore it is our first fully remote engineering role. You are of course welcome to work from our offices rather than remote but the option is open. As previously mentioned, regular communication with customers is still a must.
+    This role requires less of a physical presence with delivery teams and therefore it is our first fully remote engineering role. You are of course welcome to work from our offices rather than remote but the option is open. Being remote means regular communication and being visible is important.
 
     ## What experience are we looking for?
 
-    We’ll expect you to be a polyglot programmer versed in a mix of object and functional programming languages. We expect you to be able to jump into a project in a language, framework or configuration you’ve not worked in before and be able to fix issues, improve the codebase and build new features in it. Not only this but the right person would be adept in sharing their knowledge with others – we’d love to hear some examples of coaching and growing team members.
+    We’ll expect you to be a polyglot programmer versed in a mix of object and functional programming languages. We expect you to be able to jump into a project in a language, framework or configuration you’ve not worked in before and be able to fix issues and improve the codebase. Not only this but the right person would be adept in sharing their knowledge with others – we’d love to hear some examples of coaching and growing team members.
 
-    Multitasking, or more accurately, prioritisation is a big part of being a Reliability Engineer. We expect you to be able to prioritise your work, be able to switch onto resolving emergencies without being told to, and keep all customers up to date.
+    Multitasking, or more accurately, prioritisation is a big part of being a Reliability Engineer. We expect you to be able to prioritise your work, be able to switch onto resolving emergencies without being told to, and keep all delivery teams up to date.
 
-    Code is only the half of it. The other half is communication. We expect you to be a great communicator with customers and colleagues in written and spoken English. Reliability Engineers keep in touch with customers mostly via Slack and Google Hangouts.
+    Code is only the half of it. The other half is communication. We expect you to be a great communicator with delivery teams in written and spoken English. Reliability Engineers keep in touch with delivery teams mostly via Slack and Google Hangouts.
 
     Further required experience:
 
     - Debugging a range of applications
     - Experience debugging infrastructure (AWS/Heroku/Linux/HTTP)
-    - Working directly with customers
     - Writing code with Test Driven Development
     - Pair programming as we pair around 50% of the time
     - Agile practices such as Scrum, XP, and/or Kanban
@@ -35,6 +34,7 @@ JobSpec::Role.definition 'Senior Reliability Engineer' do
 
     Everything else is optional but highly sought after. We would love you to have experience in:
 
+    - Working directly with customers
     - Writing code with Acceptance Test Driven Development
     - Component based design techniques such as using pattern libraries, styled components, CSS-in-JS, BEM, and/or SUIT CSS
     - The React ecosystem including a TDD approach

--- a/roles/as_code/lib/shared_expectations/reliability_engineer_expectations.rb
+++ b/roles/as_code/lib/shared_expectations/reliability_engineer_expectations.rb
@@ -1,0 +1,19 @@
+class ReliabilityEngineerExpectations < JobSpec::Role::Expectations
+  expected 'to be ambassadors of reliability engineering culture',
+    'We expect our Reliability Engineers to contribute to our reliability engineering culture, standards and thought leadership. We expect Reliability Engineers to champion existing standards by working closely with delivery teams to coach and mentor them. We also expect all Reliability Engineers to be involved in discussions around improving our standards.'
+
+  expected 'to proactively identify technical improvements and recommend them to delivery teams',
+    'We expect our Reliability Engineers to be able to spot areas for improvement in codebases such as test suites, dependency upgrades, performance issues detected by monitoring. We also expect them to be able to highlight these issues in a jargon free way and be able to convey the relative urgency of the issues ultimately leading to codebases being improved.'
+
+  expected 'to autonomously deliver working software',
+    'We expect our Reliability Engineers to be able to work on entire features, from conception through to production deployment, without guidance and direction from others. This doesn\'t mean they have to be delivered without pairing, or asking advice from the wider team. What it does mean is the primary force for ensuring the feature is built and deployed in a timely fashion is the responsiblity of the Reliability Engineer working on the problem.'
+
+  expected 'to be fully billable by timesheeting 7 hours daily',
+    'We expect our Reliability Engineers to ensure they are timesheeting 7 hours daily, 4 days a week. As our Reliability Engineers rotate around teams we need to ensure we remain profitable.'
+
+  expected 'to be a responsible remote worker',
+    'We expect our Reliability Engineers to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels such as email and Slack.'
+
+  expected 'to effectively juggle commitments',
+    'We expect our Reliability Engineers to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Customer expectations need to be set and met. If they cannot be met they should be reset early and often.'
+end

--- a/roles/reliability_engineer.md
+++ b/roles/reliability_engineer.md
@@ -54,7 +54,7 @@ Other notable things:
 This role has a salary of £40-75k depending on experience.
 
 
-## Expectations
+## Reliability Engineer Expectations
 
 ### To be ambassadors of reliability engineering culture
 
@@ -66,7 +66,7 @@ We expect our Reliability Engineers to be able to spot areas for improvement in 
 
 ### To autonomously deliver working software
 
-We expect our Reliability Engineers to be able to work on entire changesets, from conception through to production deployment, without guidance and direction from others. This doesn't mean they have to be delivered without pairing, or asking advice from the wider team. What it does mean is the primary force for ensuring the changeset is built and deployed in a timely fashion is the responsiblity of the Reliability Engineer working on the problem.
+We expect our Reliability Engineers to be able to work on entire features, from conception through to production deployment, without guidance and direction from others. This doesn't mean they have to be delivered without pairing, or asking advice from the wider team. What it does mean is the primary force for ensuring the feature is built and deployed in a timely fashion is the responsiblity of the Reliability Engineer working on the problem.
 
 ### To be fully billable by timesheeting 7 hours daily
 
@@ -78,7 +78,7 @@ We expect our Reliability Engineers to communicate more than anyone else in the 
 
 ### To effectively juggle commitments
 
-We expect our Reliability Engineers to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Commitments need to be set and met. If they cannot be met they should be reset early and often.
+We expect our Reliability Engineers to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Customer expectations need to be set and met. If they cannot be met they should be reset early and often.
 
 ## Core Engineer Expectations
 

--- a/roles/reliability_engineer.md
+++ b/roles/reliability_engineer.md
@@ -51,7 +51,7 @@ Other notable things:
 
 ## Salary
 
-This role has a salary of £40-75k depending on experience.
+This role has a salary of £40-60k depending on experience.
 
 
 ## Reliability Engineer Expectations

--- a/roles/senior_reliability_engineer.md
+++ b/roles/senior_reliability_engineer.md
@@ -1,6 +1,6 @@
 # Senior Reliability Engineer
 
-Our Senior Reliability Engineers evolve and maintain applications and infrastructure for our customers. Scalability and proactive improvements are the focus and good communication skills – the necessity.
+Our Senior Reliability Engineers are champions of the Made Tech reliability engineering culture and devops in it's truest and most collaborative form. Through coaching and mentoring our reliability engineering team as well as remaining hands-on, our Senior Reliability Engineers ensure the quality of our customers applications through their lifetime.
 
 ## What does the job entail?
 
@@ -39,7 +39,7 @@ Everything else is optional but highly sought after. We would love you to have e
 
 We are a sanctuary for those wanting to hone their skills alongside like-minded learners. After joining our team it is common for new starters to comment on how much they’re learning and how much they enjoy the fact they are surrounded by people they can learn from. This includes our most senior hires.
 
-The biggest thing you’ll take away from our culture after spending the day with us would be that we practice continuous improvement at every level. Everyone has peer-based one-to-ones every 2 weeks, along with monthly one-to-ones with a director. Teams have fortnightly retrospectives. We also hold a company wide retrospective fortnightly. We discuss our problems out in the open, and rather than punish failure we band together to find solutions.
+The biggest thing you’ll take away from our culture after spending the day with us would be that we practice continuous improvement at every level. Everyone has peer-based one-to-ones every 2 weeks, along with monthly one-to-ones with a Line Manager. Teams have fortnightly retrospectives. We also hold a company wide retrospective fortnightly. We discuss our problems out in the open, and rather than punish failure we band together to find solutions.
 
 Other notable things:
 
@@ -84,11 +84,11 @@ We expect our Reliability Engineers to ensure they are timesheeting 7 hours dail
 
 ### To be a responsible remote worker
 
-We expect our Reliability Engineers team to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels such as email and Slack.
+We expect our Reliability Engineers to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels such as email and Slack.
 
 ### To effectively juggle commitments
 
-We expect our Reliability Engineers team to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Customer expectations need to be set and met. If they cannot be met they should be reset early and often.
+We expect our Reliability Engineers to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Customer expectations need to be set and met. If they cannot be met they should be reset early and often.
 
 ## Senior Engineer Expectations
 

--- a/roles/senior_reliability_engineer.md
+++ b/roles/senior_reliability_engineer.md
@@ -1,0 +1,145 @@
+# Senior Reliability Engineer
+
+Our Senior Reliability Engineers evolve and maintain applications and infrastructure for our customers. Scalability and proactive improvements are the focus and good communication skills – the necessity.
+
+## What does the job entail?
+
+We primarily write and deliver custom software to our customers. We build solutions in a variety of languages and platforms, historically Ruby on Rails, we tend to use React, JavaScript, Elixir, and Clojure these days. We will usually be responsible for setting up a customer’s infrastructure on AWS with tools like Ansible and Terraform though sometimes we opt for a Platform as a Service like Heroku. We make sure there is a Continuous Delivery pipeline running our automated test suites before deploying changes.
+
+Reliability Engineers will split their time between responding to automated alerts ensuring the uptime of our customers applications, proactive codebase improvements, coaching and mentoring delivery teams to build production-ready systems and championing reliability engineering culture more widely.
+
+This role requires less of a physical presence with customers and therefore it is our first fully remote engineering role. You are of course welcome to work from our offices rather than remote but the option is open. As previously mentioned, regular communication with customers is still a must.
+
+## What experience are we looking for?
+
+We’ll expect you to be a polyglot programmer versed in a mix of object and functional programming languages. We expect you to be able to jump into a project in a language, framework or configuration you’ve not worked in before and be able to fix issues, improve the codebase and build new features in it. Not only this but the right person would be adept in sharing their knowledge with others – we’d love to hear some examples of coaching and growing team members.
+
+Multitasking, or more accurately, prioritisation is a big part of being a Reliability Engineer. We expect you to be able to prioritise your work, be able to switch onto resolving emergencies without being told to, and keep all customers up to date.
+
+Code is only the half of it. The other half is communication. We expect you to be a great communicator with customers and colleagues in written and spoken English. Reliability Engineers keep in touch with customers mostly via Slack and Google Hangouts.
+
+Further required experience:
+
+- Debugging a range of applications
+- Experience debugging infrastructure (AWS/Heroku/Linux/HTTP)
+- Working directly with customers
+- Writing code with Test Driven Development
+- Pair programming as we pair around 50% of the time
+- Agile practices such as Scrum, XP, and/or Kanban
+- Working with a range of SQL and NoSQL databases
+- Infrastructure as code tools such as Ansible, Chef, Puppet, and/or Saltstack
+
+Everything else is optional but highly sought after. We would love you to have experience in:
+
+- Writing code with Acceptance Test Driven Development
+- Component based design techniques such as using pattern libraries, styled components, CSS-in-JS, BEM, and/or SUIT CSS
+- The React ecosystem including a TDD approach
+
+## What is it like to work at Made Tech?
+
+We are a sanctuary for those wanting to hone their skills alongside like-minded learners. After joining our team it is common for new starters to comment on how much they’re learning and how much they enjoy the fact they are surrounded by people they can learn from. This includes our most senior hires.
+
+The biggest thing you’ll take away from our culture after spending the day with us would be that we practice continuous improvement at every level. Everyone has peer-based one-to-ones every 2 weeks, along with monthly one-to-ones with a director. Teams have fortnightly retrospectives. We also hold a company wide retrospective fortnightly. We discuss our problems out in the open, and rather than punish failure we band together to find solutions.
+
+Other notable things:
+
+- Every Friday afternoon is dedicated to learning new skills
+- Everyone is encouraged to write blog posts regularly
+- Our handbook is open sourced
+- We are vegan and non-drinker friendly as well as meat-eater and drinker friendly
+- Retreats and trips every year
+
+## Salary
+
+This role has a salary of £60-75k depending on experience.
+
+
+## Reliability Engineer Expectations
+
+### To be ambassadors of reliability engineering culture
+
+We expect our Reliability Engineers to contribute to our reliability engineering culture, standards and thought leadership. We expect Reliability Engineers to champion existing standards by working closely with delivery teams to coach and mentor them. We also expect all Reliability Engineers to be involved in discussions around improving our standards.
+
+### To proactively identify technical improvements and recommend them to delivery teams
+
+We expect our Reliability Engineers to be able to spot areas for improvement in codebases such as test suites, dependency upgrades, performance issues detected by monitoring. We also expect them to be able to highlight these issues in a jargon free way and be able to convey the relative urgency of the issues ultimately leading to codebases being improved.
+
+### To autonomously deliver working software
+
+We expect our Reliability Engineers to be able to work on entire features, from conception through to production deployment, without guidance and direction from others. This doesn't mean they have to be delivered without pairing, or asking advice from the wider team. What it does mean is the primary force for ensuring the feature is built and deployed in a timely fashion is the responsiblity of the Reliability Engineer working on the problem.
+
+### To be fully billable by timesheeting 7 hours daily
+
+We expect our Reliability Engineers to ensure they are timesheeting 7 hours daily, 4 days a week. As our Reliability Engineers rotate around teams we need to ensure we remain profitable.
+
+### To be a responsible remote worker
+
+We expect our Reliability Engineers team to communicate more than anyone else in the business if they choose to work fully remote. Remote working requires extra attention to be paid to communication channels such as email and Slack.
+
+### To effectively juggle commitments
+
+We expect our Reliability Engineers team to be able to balance the priority of their work. Having an understanding of the severity of work along with expected time to fix is important and it should be used to help prioritise what to work on. Customer expectations need to be set and met. If they cannot be met they should be reset early and often.
+
+## Senior Engineer Expectations
+
+### To make sensible and well justified technical architecture decisions, involving the team in the decision making process where appropriate
+
+We expect our Senior Engineers to be able to design and implement appropriate technical architectures to solve problems. We expect them to appropriately involve the team in the decision making process to help them develop their technical architecture skills.
+
+### To have attained the Made Tech Core Skills
+
+We expect our Senior Engineers to be an expert in their craft, practising and coaching others in the Made Tech Core Skills
+
+### To be willing and able to pick up new programming languages, technologies and techniques
+
+We expect our Senior Engineers to be actively researching and trialling new technologies and techniques. We expect them to be regularly sharing their knowledge whether that is during focussed learning sessions, talks, or via pairing.
+
+### To be leading the way with introducing new technologies to deliveries
+
+We expect our Senior Engineers to help teams use new technologies as part of deliveries. We expect them to make suggestions before new projects boot up and to help the adoption of the technology during the delivery through pairing and otherwise coaching their colleagues.
+
+### To advocate lean and iterative approaches to solving problems
+
+We expect our Senior Engineers to always push for solving a problem with the simplest, most sensible solution rather than taking a more over-engineered approach. We expect them to encourage an early and often approach for getting functionality into production.
+
+## Core Engineer Expectations
+
+### To be actively practicing TDD
+
+We expect our engineering team to write tests first by default. We expect every feature to be tested. Every Pull Request (or equivalent chunk of work put up for peer review) must contain a test. If for some reason there are extenuating circumstances for not writing tests then more than one engineer should peer review and verify this.
+
+### To productively pair with their colleagues
+
+We expect our engineering team to be friendly and lovely people to pair with. All pairing dynamics are different, sometimes you will be pairing with someone with less experience, sometimes you will have the same experience. Adjusting the speed of your work to accomodate for your pair is important and special care must be taken when mentoring/coaching those with less experience. No matter who you are pairing with you must take turns to compromise when your opinions differ.
+
+### To request peer reviews for the code they write
+
+We expect our engineering team to always have their code peer reviewed at the least by one other person before merging. It's the responsibility of the code author to ask their colleagues to review and to merge the code in a timely fashion.
+
+### To provide meaningful and considerate peer reviews for others
+
+We expect our engineering team to provide feedback that makes code safer, easier to maintain and advances the knowledge of the original author. We expect everyone to negotiate and compromise when making a call on whether feedback should be addressed or not.
+
+### To regularly communicate with customers without reminder
+
+We expect our engineering team to keep their customers up to date with progress. Customers should be invited to standups or at appropriate points in time. A customer should never have to chase us for an update.
+
+### To keep their team updated on current work in progress
+
+We expect our engineering team to keep their fellow team members up to date with their progress. A good litmus test for this is everyone on the team can describe what their team mates are up to.
+
+### To ensure team ceremonies are held regularly
+
+We expect our engineering team to ensure team ceremonies such as planning, retrospectives, and standups happen on a regular basis.
+
+### To facilitate showcases and retrospectives
+
+We expect our engineering team to be able to demonstrate the successes of their iterations with weekly showcases to customers. We also expect Engineers to be able to facilitate retrospectives with engaging formats and customer involvement. Good teams will rotate this responsibility on a weekly basis.
+
+### To be responsible for the security of devices used for work
+
+We expect our engineering team to understand how to secure the devices they use for work including work issued laptops, personal computers, mobile phones, and other electronic devices. We expect invididuals to ensure they adhere to our [security guidelines](https://github.com/madetech/handbook/blob/master/guides/security/protect_the_company.md) upon setting up devices and to ensure that their machines are compliant at all times.
+
+### To be involved in practice improvement discussions
+
+We expect our engineering team to reflect on our practices and be a proactive voice in suggesting change. We expect you to be reflecting on your own development practices, reflecting on your team and the wider business.

--- a/roles/senior_reliability_engineer.md
+++ b/roles/senior_reliability_engineer.md
@@ -6,7 +6,9 @@ Our Senior Reliability Engineers are champions of the Made Tech reliability engi
 
 We primarily write and deliver custom software to our customers. We build solutions in a variety of languages and platforms, historically Ruby on Rails, we tend to use React, JavaScript, Elixir, and Clojure these days. We will usually be responsible for setting up a customer’s infrastructure on AWS with tools like Ansible and Terraform though sometimes we opt for a Platform as a Service like Heroku. We make sure there is a Continuous Delivery pipeline running our automated test suites before deploying changes.
 
-Reliability Engineers will split their time between responding to automated alerts ensuring the uptime of applications, proactive codebase improvements, coaching and mentoring delivery teams to build production-ready systems and championing reliability engineering culture more widely. Reliability Engineers serve our delivery teams who ultimately serve our customers.
+Senior Reliability Engineers will split their time between responding to automated alerts ensuring the uptime of applications, proactive codebase improvements, coaching and mentoring delivery teams to build production-ready systems and championing reliability engineering culture more widely. Senior Reliability Engineers serve our delivery teams who ultimately serve our customers.
+
+Senior Reliability Engineers are also responsible for coaching and mentoring other members of the reliability engineering team as well as championing reliability engineering culture more widely.
 
 This role requires less of a physical presence with delivery teams and therefore it is our first fully remote engineering role. You are of course welcome to work from our offices rather than remote but the option is open. Being remote means regular communication and being visible is important.
 

--- a/roles/senior_reliability_engineer.md
+++ b/roles/senior_reliability_engineer.md
@@ -1,28 +1,27 @@
 # Senior Reliability Engineer
 
-Our Senior Reliability Engineers are champions of the Made Tech reliability engineering culture and devops in it's truest and most collaborative form. Through coaching and mentoring our reliability engineering team as well as remaining hands-on, our Senior Reliability Engineers ensure the quality of our customers applications through their lifetime.
+Our Senior Reliability Engineers are champions of the Made Tech reliability engineering culture and DevOps in it's truest and most collaborative form. Through coaching and mentoring our reliability engineering team as well as remaining hands-on, our Senior Reliability Engineers ensure the quality of applications through their lifetime.
 
 ## What does the job entail?
 
 We primarily write and deliver custom software to our customers. We build solutions in a variety of languages and platforms, historically Ruby on Rails, we tend to use React, JavaScript, Elixir, and Clojure these days. We will usually be responsible for setting up a customer’s infrastructure on AWS with tools like Ansible and Terraform though sometimes we opt for a Platform as a Service like Heroku. We make sure there is a Continuous Delivery pipeline running our automated test suites before deploying changes.
 
-Reliability Engineers will split their time between responding to automated alerts ensuring the uptime of our customers applications, proactive codebase improvements, coaching and mentoring delivery teams to build production-ready systems and championing reliability engineering culture more widely.
+Reliability Engineers will split their time between responding to automated alerts ensuring the uptime of applications, proactive codebase improvements, coaching and mentoring delivery teams to build production-ready systems and championing reliability engineering culture more widely. Reliability Engineers serve our delivery teams who ultimately serve our customers.
 
-This role requires less of a physical presence with customers and therefore it is our first fully remote engineering role. You are of course welcome to work from our offices rather than remote but the option is open. As previously mentioned, regular communication with customers is still a must.
+This role requires less of a physical presence with delivery teams and therefore it is our first fully remote engineering role. You are of course welcome to work from our offices rather than remote but the option is open. Being remote means regular communication and being visible is important.
 
 ## What experience are we looking for?
 
-We’ll expect you to be a polyglot programmer versed in a mix of object and functional programming languages. We expect you to be able to jump into a project in a language, framework or configuration you’ve not worked in before and be able to fix issues, improve the codebase and build new features in it. Not only this but the right person would be adept in sharing their knowledge with others – we’d love to hear some examples of coaching and growing team members.
+We’ll expect you to be a polyglot programmer versed in a mix of object and functional programming languages. We expect you to be able to jump into a project in a language, framework or configuration you’ve not worked in before and be able to fix issues and improve the codebase. Not only this but the right person would be adept in sharing their knowledge with others – we’d love to hear some examples of coaching and growing team members.
 
-Multitasking, or more accurately, prioritisation is a big part of being a Reliability Engineer. We expect you to be able to prioritise your work, be able to switch onto resolving emergencies without being told to, and keep all customers up to date.
+Multitasking, or more accurately, prioritisation is a big part of being a Reliability Engineer. We expect you to be able to prioritise your work, be able to switch onto resolving emergencies without being told to, and keep all delivery teams up to date.
 
-Code is only the half of it. The other half is communication. We expect you to be a great communicator with customers and colleagues in written and spoken English. Reliability Engineers keep in touch with customers mostly via Slack and Google Hangouts.
+Code is only the half of it. The other half is communication. We expect you to be a great communicator with delivery teams in written and spoken English. Reliability Engineers keep in touch with delivery teams mostly via Slack and Google Hangouts.
 
 Further required experience:
 
 - Debugging a range of applications
 - Experience debugging infrastructure (AWS/Heroku/Linux/HTTP)
-- Working directly with customers
 - Writing code with Test Driven Development
 - Pair programming as we pair around 50% of the time
 - Agile practices such as Scrum, XP, and/or Kanban
@@ -31,6 +30,7 @@ Further required experience:
 
 Everything else is optional but highly sought after. We would love you to have experience in:
 
+- Working directly with customers
 - Writing code with Acceptance Test Driven Development
 - Component based design techniques such as using pattern libraries, styled components, CSS-in-JS, BEM, and/or SUIT CSS
 - The React ecosystem including a TDD approach

--- a/roles/senior_reliability_engineer.md
+++ b/roles/senior_reliability_engineer.md
@@ -54,6 +54,16 @@ Other notable things:
 This role has a salary of £60-75k depending on experience.
 
 
+## Expectations
+
+### To drive the reliability engineering agenda across Made Tech
+
+We expect the Senior Reliability Engineers to drive the reliability engineering agenda across the business. They should set the standard for what "good" looks like for applications from a maintainability, scalability, and security perspective, and ensure delivery teams understand are bought in to these standards.
+
+### To coach and nurture team members to improve their reliability engineering capability
+
+We expect our Senior Reliability Engineers to proactively provide thoughtful and meaningful feedback for their team. A Senior Reliability Engineer is expected to spend time helping team members to improve their skills. A Senior Reliability Engineer is expected to identify and nurture candidates for Senior Reliability Engineer positions.
+
 ## Reliability Engineer Expectations
 
 ### To be ambassadors of reliability engineering culture


### PR DESCRIPTION
We introduce progression for Reliability Engineers by combining Senior and RE role expectations.

Todo:

 - [x] Decide if there are any RE specific senior requirements
 - [x] Update job description to make clear differentiation between RE and Senior RE