### PR TITLE
Add Technical Principal role

### DIFF
--- a/roles/as_code/lib/lead_engineer.rb
+++ b/roles/as_code/lib/lead_engineer.rb
@@ -1,6 +1,6 @@
 require_relative './shared_expectations/core_engineer_expectations'
 require_relative './shared_expectations/senior_engineer_expectations'
-require_relative './shared_expectations/delivery_lead_expectations'
+require_relative './shared_expectations/commercially_aware_engineer_expectations'
 
 JobSpec::Role.definition 'Lead Engineer' do
   description <<~DESCRIPTION
@@ -68,15 +68,7 @@ JobSpec::Role.definition 'Lead Engineer' do
   expected 'to lead workshop and roadmapping sessions to understand customer requirements and convert these in to deliverable iterations',
     'We expect our Lead Engineers to lead workshop and roadmapping sessions, and foster collaboration with the wider team to identify a technology roadmap to solve business problems.'
 
-  expected 'to quickly become a trusted partner to the customer team, building a friendly relationship',
-    'We expect our Lead Engineers to quickly become a trusted partner to the customer team - both our day-to-day contacts, and more senior stakeholders. A Lead Engineer should be able to put a customer at ease by engaging in small talk, and by building strong and friendly working relationships. A Lead Engineer is expected to credibly and knowledgeably represent Made Tech when conversing with senior stakeholders.'
-
-  expected 'to proactively identify opportunities where we can widen the impact of our work with the customer organisation',
-    'We expect our Lead Engineers to proactively seek opportunities where we can extend our remit with the customer organisation. A Lead Engineer is expected to understand the objectives of our stakeholders, and to sell Made Tech’s wider capabilities.'
-
-  expected 'to make sensible, well reasoned commercial decisions',
-    'We expect our Lead Engineers to proactively make good commercial decisions. A Lead Engineer is expected to identify and course correct potential delivery issues before they become impactful. A Lead Engineer is expected to proactively escalate larger delivery issues to the Delivery Manager or Delivery Director.'
-
+  include CommerciallyAwareEngineerExpectations, as: 'Commercially Aware Engineer Expectations'
   include SeniorEngineerExpectations, as: 'Senior Engineer Expectations'
   include CoreEngineerExpectations, as: 'Core Engineer Expectations'
 end

--- a/roles/as_code/lib/shared_expectations/commercially_aware_engineer_expectations.rb
+++ b/roles/as_code/lib/shared_expectations/commercially_aware_engineer_expectations.rb
@@ -1,0 +1,10 @@
+class CommerciallyAwareEngineerExpectations < JobSpec::Role::Expectations
+  expected 'to quickly become a trusted partner to the customer team, building a friendly relationship',
+    'We expect our commercially aware engineers to quickly become a trusted partner to the customer team - both our day-to-day contacts, and more senior stakeholders. A commercially aware engineer should be able to put a customer at ease by engaging in small talk, and by building strong and friendly working relationships. A commercially aware engineer is expected to credibly and knowledgeably represent Made Tech when conversing with senior stakeholders.'
+
+  expected 'to proactively identify opportunities where we can widen the impact of our work with the customer organisation',
+    'We expect our commercially aware engineers to proactively seek opportunities where we can extend our remit with the customer organisation. A commercially aware engineer is expected to understand the objectives of our stakeholders, and to sell Made Tech’s wider capabilities.'
+
+  expected 'to make sensible, well reasoned commercial decisions',
+    'We expect our commercially aware engineers to proactively make good commercial decisions. A commercially aware engineer is expected to identify and course correct potential delivery issues before they become impactful. A commercially aware engineer is expected to proactively escalate larger delivery issues to the Delivery Manager or Delivery Director.'
+end

--- a/roles/as_code/lib/technical_principal.rb
+++ b/roles/as_code/lib/technical_principal.rb
@@ -1,0 +1,79 @@
+require_relative './shared_expectations/core_engineer_expectations'
+require_relative './shared_expectations/senior_engineer_expectations'
+require_relative './shared_expectations/commercially_aware_engineer_expectations'
+
+JobSpec::Role.definition 'Technical Principal' do
+  description <<~DESCRIPTION
+    Our Technical Principals are consultative engineers who are commercially responsible for growing Made Tech both in terms of maintaining the quality of our teams as we scale and in helping win new business.
+
+    ## What does the job entail?
+
+    Technical Principals sit across multiple delivery teams ensuring software engineering excellence and engaging in technical discovery work.
+
+    Through coaching and mentoring Technical Pricipals will make sure Leads and Seniors are equipped with the skills needed to be successful in delivery. They will be helping grow our team into successful technical leaders and be responsible for helping others become Technical Pricipals.
+
+    As an escalation point for software engineering issues, Technical Principals will be on hand when necessary, and to involve the wider engineering team if necessary.
+
+    Helping in technical discovery work, Technical Principals will be able to engage in stakeholder workshops, technical feasibility studies, high level roadmapping, and ultimately shape up next steps for a Made Tech delivery team to be engaged.
+
+    Technical Principals are expected to be seen as thought leaders in software engineering, to talk about our work in public, to remain technically current and push engineering at Made Tech forward.
+
+    ## What does software delivery look like at Made Tech?
+
+    We primarily write and deliver custom software to our customers. Before a project kicks off we will have a number of sessions where we begin to understand the customer’s business and what they are looking to achieve. We then formulate a roadmap for them, potentially a business case too, before starting delivery.
+
+    We build solutions in a variety of languages and platforms, historically Ruby on Rails, we tend to use React, JavaScript, Elixir, and Clojure these days. We will usually be responsible for setting up a customer’s infrastructure on AWS with tools like Ansible and Terraform though sometimes we opt for a Platform as a Service like Heroku. We make sure there is a Continuous Delivery pipeline running our automated test suites before deploying changes.
+
+    The software we build solves business problems. We’ve built software for karaoke, e-commerce, retail buying departments, accountants, photography studios, warehouses, supply chain companies, and ourselves. Typical projects will last 3-6 months, some customers work with us over longer periods but we like to mix up teams at around 6 months to keep things fresh.
+
+    ## What experience are we looking for?
+
+    We’ll expect you to be a polyglot programmer versed in a mix of object and functional programming languages. We’d expect you to have some blog posts about your discipline, perhaps even a talk or two. Not only this but the right person would be adept in sharing their knowledge with others – we’d love to hear some examples of coaching and growing team members.
+
+    We expect you to have experience architecting and leading software delivery teams, helping guide technical decision making in a servant leader approach. We expect you to have significant experience in designing and developing web applications in modern cloud-based environments.
+
+    Business savvy is a must. You will need experience in translating business goals and issues into technical solutions and have success stories to share. You will need to demonstrate experience working with senior IT stakeholders and working directly with CTO/COOs to create technical strategies.
+
+    ## What is it like to work at Made Tech?
+
+    We are a sanctuary for those wanting to hone their skills alongside like-minded learners. After joining our team it is common for new starters to comment on how much they’re learning and how much they enjoy the fact they are surrounded by people they can learn from. This includes our most senior hires.
+
+    The biggest thing you’ll take away from our culture after spending the day with us would be that we practice continuous improvement at every level. Everyone has peer-based one-to-ones every 2 weeks, along with monthly one-to-ones with a Line Manager. Teams have fortnightly retrospectives. We also hold a company wide retrospective fortnightly. We discuss our problems out in the open, and rather than punish failure we band together to find solutions.
+
+    Other notable things:
+
+    - Every Friday afternoon is dedicated to learning new skills
+    - Everyone is encouraged to write blog posts regularly
+    - Our handbook is open sourced
+    - We are vegan and non-drinker friendly as well as meat-eater and drinker friendly
+    - Retreats and trips every year
+
+    ## Salary
+
+    This role has a salary of £85-95k depending on experience.
+  DESCRIPTION
+
+  salary 85_000..95_000
+
+  expected 'to act as a role model and servant leader to their teams',
+    'We expect our Technical Principals to lead by example, to put the needs of others before their own, and to set and demonstrate a high standard for code and delivery quality. A Technical Principal is expected to show themselves to be highly reliable, to be on time, and to be well prepared.'
+
+  expected 'to coach and nurture Lead and Senior Engineers',
+    'We expect our Technical Principals to proactively provide thoughtful and meaningful feedback for their team. A Technical Principal is expected to spend time helping team members to improve their skills. A Technical Principal is expected to identify and nurture candidates for Technical Principal positions. A Technical Principal is expected to identify and escalate performance issues to a relevant Line Manager.'
+
+  expected 'to be a point of escalation for software engineering issues',
+    'We expect our Technical Principals to be a point of escalation when a delivery team are struggling with software engineering issues. Technical Principals will look to quickly remedy issues and pull in the wider engineering team if necessary.'
+
+  expected 'to coach and support teams running workshops and roadmapping sessions',
+    'We expect our Technical Principals to coach teams to be able to run workshops and roadmapping sessions, to provide a supporting role in important sessions, and foster collaboration with the wider team to identify a technology roadmap to solve business problems.'
+
+  expected 'to run technical discovery projects',
+    'We expect our Technical Principals to run technical discoveries. Technical Principals are responsible for planning, workshopping, running technical feasibility studies, and ultimately recommending strategies to customers.'
+
+  expected 'to be partner with customer tech leadership (CTO/CIO) to help shape their technology strategies',
+    'We expect our Technical Pricipals to be able to engage the highest levels of technical leadership within our customers organisations. Through building strong relationships Technical Principals will be seen as trusted advisors.'
+
+  include CommerciallyAwareEngineerExpectations, as: 'Commercially Aware Engineer Expectations'
+  include SeniorEngineerExpectations, as: 'Senior Engineer Expectations'
+  include CoreEngineerExpectations, as: 'Core Engineer Expectations'
+end

--- a/roles/lead_engineer.md
+++ b/roles/lead_engineer.md
@@ -67,17 +67,19 @@ We expect our Lead Engineers to proactively provide thoughtful and meaningful fe
 
 We expect our Lead Engineers to lead workshop and roadmapping sessions, and foster collaboration with the wider team to identify a technology roadmap to solve business problems.
 
+## Commercially Aware Engineer Expectations
+
 ### To quickly become a trusted partner to the customer team, building a friendly relationship
 
-We expect our Lead Engineers to quickly become a trusted partner to the customer team - both our day-to-day contacts, and more senior stakeholders. A Lead Engineer should be able to put a customer at ease by engaging in small talk, and by building strong and friendly working relationships. A Lead Engineer is expected to credibly and knowledgeably represent Made Tech when conversing with senior stakeholders.
+We expect our commercially aware engineers to quickly become a trusted partner to the customer team - both our day-to-day contacts, and more senior stakeholders. A commercially aware engineer should be able to put a customer at ease by engaging in small talk, and by building strong and friendly working relationships. A commercially aware engineer is expected to credibly and knowledgeably represent Made Tech when conversing with senior stakeholders.
 
 ### To proactively identify opportunities where we can widen the impact of our work with the customer organisation
 
-We expect our Lead Engineers to proactively seek opportunities where we can extend our remit with the customer organisation. A Lead Engineer is expected to understand the objectives of our stakeholders, and to sell Made Tech’s wider capabilities.
+We expect our commercially aware engineers to proactively seek opportunities where we can extend our remit with the customer organisation. A commercially aware engineer is expected to understand the objectives of our stakeholders, and to sell Made Tech’s wider capabilities.
 
 ### To make sensible, well reasoned commercial decisions
 
-We expect our Lead Engineers to proactively make good commercial decisions. A Lead Engineer is expected to identify and course correct potential delivery issues before they become impactful. A Lead Engineer is expected to proactively escalate larger delivery issues to the Delivery Manager or Delivery Director.
+We expect our commercially aware engineers to proactively make good commercial decisions. A commercially aware engineer is expected to identify and course correct potential delivery issues before they become impactful. A commercially aware engineer is expected to proactively escalate larger delivery issues to the Delivery Manager or Delivery Director.
 
 ## Senior Engineer Expectations
 

--- a/roles/technical_principal.md
+++ b/roles/technical_principal.md
@@ -1,0 +1,154 @@
+# Technical Principal
+
+Our Technical Principals are consultative engineers who are commercially responsible for growing Made Tech both in terms of maintaining the quality of our teams as we scale and in helping win new business.
+
+## What does the job entail?
+
+Technical Principals sit across multiple delivery teams ensuring software engineering excellence and engaging in technical discovery work.
+
+Through coaching and mentoring Technical Pricipals will make sure Leads and Seniors are equipped with the skills needed to be successful in delivery. They will be helping grow our team into successful technical leaders and be responsible for helping others become Technical Pricipals.
+
+As an escalation point for software engineering issues, Technical Principals will be on hand when necessary, and to involve the wider engineering team if necessary.
+
+Helping in technical discovery work, Technical Principals will be able to engage in stakeholder workshops, technical feasibility studies, high level roadmapping, and ultimately shape up next steps for a Made Tech delivery team to be engaged.
+
+Technical Principals are expected to be seen as thought leaders in software engineering, to talk about our work in public, to remain technically current and push engineering at Made Tech forward.
+
+## What does software delivery look like at Made Tech?
+
+We primarily write and deliver custom software to our customers. Before a project kicks off we will have a number of sessions where we begin to understand the customer’s business and what they are looking to achieve. We then formulate a roadmap for them, potentially a business case too, before starting delivery.
+
+We build solutions in a variety of languages and platforms, historically Ruby on Rails, we tend to use React, JavaScript, Elixir, and Clojure these days. We will usually be responsible for setting up a customer’s infrastructure on AWS with tools like Ansible and Terraform though sometimes we opt for a Platform as a Service like Heroku. We make sure there is a Continuous Delivery pipeline running our automated test suites before deploying changes.
+
+The software we build solves business problems. We’ve built software for karaoke, e-commerce, retail buying departments, accountants, photography studios, warehouses, supply chain companies, and ourselves. Typical projects will last 3-6 months, some customers work with us over longer periods but we like to mix up teams at around 6 months to keep things fresh.
+
+## What experience are we looking for?
+
+We’ll expect you to be a polyglot programmer versed in a mix of object and functional programming languages. We’d expect you to have some blog posts about your discipline, perhaps even a talk or two. Not only this but the right person would be adept in sharing their knowledge with others – we’d love to hear some examples of coaching and growing team members.
+
+We expect you to have experience architecting and leading software delivery teams, helping guide technical decision making in a servant leader approach. We expect you to have significant experience in designing and developing web applications in modern cloud-based environments.
+
+Business savvy is a must. You will need experience in translating business goals and issues into technical solutions and have success stories to share. You will need to demonstrate experience working with senior IT stakeholders and working directly with CTO/COOs to create technical strategies.
+
+## What is it like to work at Made Tech?
+
+We are a sanctuary for those wanting to hone their skills alongside like-minded learners. After joining our team it is common for new starters to comment on how much they’re learning and how much they enjoy the fact they are surrounded by people they can learn from. This includes our most senior hires.
+
+The biggest thing you’ll take away from our culture after spending the day with us would be that we practice continuous improvement at every level. Everyone has peer-based one-to-ones every 2 weeks, along with monthly one-to-ones with a Line Manager. Teams have fortnightly retrospectives. We also hold a company wide retrospective fortnightly. We discuss our problems out in the open, and rather than punish failure we band together to find solutions.
+
+Other notable things:
+
+- Every Friday afternoon is dedicated to learning new skills
+- Everyone is encouraged to write blog posts regularly
+- Our handbook is open sourced
+- We are vegan and non-drinker friendly as well as meat-eater and drinker friendly
+- Retreats and trips every year
+
+## Salary
+
+This role has a salary of £85-95k depending on experience.
+
+
+## Expectations
+
+### To act as a role model and servant leader to their teams
+
+We expect our Technical Principals to lead by example, to put the needs of others before their own, and to set and demonstrate a high standard for code and delivery quality. A Technical Principal is expected to show themselves to be highly reliable, to be on time, and to be well prepared.
+
+### To coach and nurture Lead and Senior Engineers
+
+We expect our Technical Principals to proactively provide thoughtful and meaningful feedback for their team. A Technical Principal is expected to spend time helping team members to improve their skills. A Technical Principal is expected to identify and nurture candidates for Technical Principal positions. A Technical Principal is expected to identify and escalate performance issues to a relevant Line Manager.
+
+### To be a point of escalation for software engineering issues
+
+We expect our Technical Principals to be a point of escalation when a delivery team are struggling with software engineering issues. Technical Principals will look to quickly remedy issues and pull in the wider engineering team if necessary.
+
+### To coach and support teams running workshops and roadmapping sessions
+
+We expect our Technical Principals to coach teams to be able to run workshops and roadmapping sessions, to provide a supporting role in important sessions, and foster collaboration with the wider team to identify a technology roadmap to solve business problems.
+
+### To run technical discovery projects
+
+We expect our Technical Principals to run technical discoveries. Technical Principals are responsible for planning, workshopping, running technical feasibility studies, and ultimately recommending strategies to customers.
+
+### To be partner with customer tech leadership (CTO/CIO) to help shape their technology strategies
+
+We expect our Technical Pricipals to be able to engage the highest levels of technical leadership within our customers organisations. Through building strong relationships Technical Principals will be seen as trusted advisors.
+
+## Commercially Aware Engineer Expectations
+
+### To quickly become a trusted partner to the customer team, building a friendly relationship
+
+We expect our commercially aware engineers to quickly become a trusted partner to the customer team - both our day-to-day contacts, and more senior stakeholders. A commercially aware engineer should be able to put a customer at ease by engaging in small talk, and by building strong and friendly working relationships. A commercially aware engineer is expected to credibly and knowledgeably represent Made Tech when conversing with senior stakeholders.
+
+### To proactively identify opportunities where we can widen the impact of our work with the customer organisation
+
+We expect our commercially aware engineers to proactively seek opportunities where we can extend our remit with the customer organisation. A commercially aware engineer is expected to understand the objectives of our stakeholders, and to sell Made Tech’s wider capabilities.
+
+### To make sensible, well reasoned commercial decisions
+
+We expect our commercially aware engineers to proactively make good commercial decisions. A commercially aware engineer is expected to identify and course correct potential delivery issues before they become impactful. A commercially aware engineer is expected to proactively escalate larger delivery issues to the Delivery Manager or Delivery Director.
+
+## Senior Engineer Expectations
+
+### To make sensible and well justified technical architecture decisions, involving the team in the decision making process where appropriate
+
+We expect our Senior Engineers to be able to design and implement appropriate technical architectures to solve problems. We expect them to appropriately involve the team in the decision making process to help them develop their technical architecture skills.
+
+### To have attained the Made Tech Core Skills
+
+We expect our Senior Engineers to be an expert in their craft, practising and coaching others in the Made Tech Core Skills
+
+### To be willing and able to pick up new programming languages, technologies and techniques
+
+We expect our Senior Engineers to be actively researching and trialling new technologies and techniques. We expect them to be regularly sharing their knowledge whether that is during focussed learning sessions, talks, or via pairing.
+
+### To be leading the way with introducing new technologies to deliveries
+
+We expect our Senior Engineers to help teams use new technologies as part of deliveries. We expect them to make suggestions before new projects boot up and to help the adoption of the technology during the delivery through pairing and otherwise coaching their colleagues.
+
+### To advocate lean and iterative approaches to solving problems
+
+We expect our Senior Engineers to always push for solving a problem with the simplest, most sensible solution rather than taking a more over-engineered approach. We expect them to encourage an early and often approach for getting functionality into production.
+
+## Core Engineer Expectations
+
+### To be actively practicing TDD
+
+We expect our engineering team to write tests first by default. We expect every feature to be tested. Every Pull Request (or equivalent chunk of work put up for peer review) must contain a test. If for some reason there are extenuating circumstances for not writing tests then more than one engineer should peer review and verify this.
+
+### To productively pair with their colleagues
+
+We expect our engineering team to be friendly and lovely people to pair with. All pairing dynamics are different, sometimes you will be pairing with someone with less experience, sometimes you will have the same experience. Adjusting the speed of your work to accomodate for your pair is important and special care must be taken when mentoring/coaching those with less experience. No matter who you are pairing with you must take turns to compromise when your opinions differ.
+
+### To request peer reviews for the code they write
+
+We expect our engineering team to always have their code peer reviewed at the least by one other person before merging. It's the responsibility of the code author to ask their colleagues to review and to merge the code in a timely fashion.
+
+### To provide meaningful and considerate peer reviews for others
+
+We expect our engineering team to provide feedback that makes code safer, easier to maintain and advances the knowledge of the original author. We expect everyone to negotiate and compromise when making a call on whether feedback should be addressed or not.
+
+### To regularly communicate with customers without reminder
+
+We expect our engineering team to keep their customers up to date with progress. Customers should be invited to standups or at appropriate points in time. A customer should never have to chase us for an update.
+
+### To keep their team updated on current work in progress
+
+We expect our engineering team to keep their fellow team members up to date with their progress. A good litmus test for this is everyone on the team can describe what their team mates are up to.
+
+### To ensure team ceremonies are held regularly
+
+We expect our engineering team to ensure team ceremonies such as planning, retrospectives, and standups happen on a regular basis.
+
+### To facilitate showcases and retrospectives
+
+We expect our engineering team to be able to demonstrate the successes of their iterations with weekly showcases to customers. We also expect Engineers to be able to facilitate retrospectives with engaging formats and customer involvement. Good teams will rotate this responsibility on a weekly basis.
+
+### To be responsible for the security of devices used for work
+
+We expect our engineering team to understand how to secure the devices they use for work including work issued laptops, personal computers, mobile phones, and other electronic devices. We expect invididuals to ensure they adhere to our [security guidelines](https://github.com/madetech/handbook/blob/master/guides/security/protect_the_company.md) upon setting up devices and to ensure that their machines are compliant at all times.
+
+### To be involved in practice improvement discussions
+
+We expect our engineering team to reflect on our practices and be a proactive voice in suggesting change. We expect you to be reflecting on your own development practices, reflecting on your team and the wider business.


### PR DESCRIPTION
We add a Technical Principal role to enable directors to step back from the technical side of deliveries, to enable us to run more technical discovery work, and to help grow the business by maintaining engineering excellence.

We also move some Lead Engineer expectations into "Commercially Aware Engineer" expectations so they can be shared with the Technical Principal role.