### PR TITLE
Create Internal delivery team support process

### DIFF
--- a/guides/internal_delivery_support_requests.md
+++ b/guides/internal_delivery_support_requests.md
@@ -1,0 +1,27 @@
+# Internal delivery team support process
+
+## Process purpose
+This outlines how you can request technical support for internal work including projects and Sales activities. 
+
+## Who is responsible for enacting this process:
+Anyone who needs to request the support of delivery team members should contact the Operations Team using the following steps. 
+
+## Sales Support
+
+1. Once you have identified the need for support for Sales opportunities, flag the need to `@ops` in the #team-resourcing channel on slack to discuss.
+2. Once any discussions have taken place, fill out this form to confirm the details of your request: [Sales Support Form](https://goo.gl/forms/cBrSte2yCLgIFV3G3)
+3. The Operations Team will do their best to find the right delivery team member for the opportunity
+4. Once the Operations Team have the agreement from a delivery team member and their engagement lead, they will reconfirm the details with you and you can pass all relevant opportunity details to the software engineer directly.
+
+## Internal projects
+
+Where an internal projet requires internal support from delivery team members that will take them away from billable projects, we need to track the impact upon team budgets.
+
+1. If you have a project internal to Made Tech, flag your request in the #team-resourcing channel and fill in this form: [Internal Support Form](https://goo.gl/forms/Jm6UDdQK0PAlxhPo1) 
+2. The Operations Team will assess the request. If your project requires more than a full day's billing from the team (7 hours) it will need to be put to the directors for approval
+3. If it is less than a full day or gets approval from the directors, the Operations Team will contact the delivery team member and their team leads to confirm their availability.
+4. Once this is done the Operations Team will report back the confirmed availability. 
+5. The Operations Team will set up a Harvest budget for you to track the progress of your project.
+6. If your project looks like it will run over flag to `@ops` in the #team-resourcing channel.
+
+If your project is over 7 hours and you need to present to the directors, you will be asked to present an estimate of the internal costs. The cost is £780 per day, per software engineer. If you need help, contact `@ops` in the #team-resourcing channel. 

--- a/guides/internal_delivery_support_requests.md
+++ b/guides/internal_delivery_support_requests.md
@@ -15,7 +15,7 @@ Anyone who needs to request the support of delivery team members should contact 
 
 ## Internal projects
 
-Where an internal projet requires internal support from delivery team members that will take them away from billable projects, we need to track the impact upon team budgets.
+Where an internal project requires internal support from delivery team members that will take them away from billable projects, we need to track the impact upon team budgets.
 
 1. If you have a project internal to Made Tech, flag your request in the #team-resourcing channel and fill in this form: [Internal Support Form](https://goo.gl/forms/Jm6UDdQK0PAlxhPo1) 
 2. The Operations Team will assess the request. If your project requires more than a full day's billing from the team (7 hours) it will need to be put to the directors for approval

--- a/guides/internal_delivery_support_requests.md
+++ b/guides/internal_delivery_support_requests.md
@@ -1,7 +1,7 @@
 # Internal delivery team support process
 
 ## Process purpose
-This outlines how you can request technical support for internal work including projects and Sales activities. 
+This outlines how you can request delivery team support for internal work including projects and Sales activities. 
 
 ## Who is responsible for enacting this process:
 Anyone who needs to request the support of delivery team members should contact the Operations Team using the following steps. 


### PR DESCRIPTION
**What:**
This is a guide to requesting support of delivery team members for sales opportunities or internal projects.

**Why we want to introduce this process:**
Spinning up internal delivery team support is a process that requires clarity over the details before it can take place. These processes aim to enable team members requiring support to provide the necessary information to the Operations Team to get their requests fulfilled as efficiently and effectively as possible. It also ensures that the details of your request go to a consistent location and are not lost in slack direct messages.