### PR TITLE
Creating and changing delivery teams process

### DIFF
--- a/guides/creating_and_changing_delivery_team.md
+++ b/guides/creating_and_changing_delivery_team.md
@@ -1,0 +1,16 @@
+# Creating and changing delivery teams
+
+## Purpose
+This process outlines the information the Operations Team need and the process they follow to spin up a new delivery team for a customer, or to make changes to an existing delivery team. This process is referred to as **resourcing**.
+
+## Who is responsible for enacting this process:
+* Sales team: when bringing in new customers
+* Engagement Leads: when clients express a need, or you feel you need to change team shape
+
+## How to request support
+1. Once there is 100% certainty (signed contract) or the approval of 2 directors to spin up a delivery team for a customer, fill out this form to confirm the details of your request: [Resourcing Delivery Request Form](https://goo.gl/forms/KBp22QlVpz6JZExO2)
+2. Any additional details can be raised in the *#team-resourcing* channel on Slack for discussion with the Operations Team.
+3. The Operations Team will discuss the potential team shape at the next resourcing meeting. They will also undertake discussions with the potential team members and confirm their availability for the project.
+4. Once the Operations Team have the agreement from a delivery team member and their engagement lead, they will let you know the final team shape for you to confirm with the client.
+
+The Operations Team will discuss your request at the next weekly resourcing meeting. If you need a faster response, please contact `@ops` in the *#team-resourcing* channel on Slack


### PR DESCRIPTION
**What:**
This is a guide to submitting a request to the Operations Team about starting a new delivery team for a new customer coming in from Sales, or changing the structure of an existing delivery team.

**Why we want to introduce this process:**
Spinning up a delivery team support is a process that requires clarity over the details before it can take place. These processes aim to enable the Operations Team to get new delivery teams started as efficiently and effectively as possible. It also ensures that the details of your request go to a consistent location and are not lost in slack direct messages.