### PR TITLE
Correct link to Common Ailments & Cures

### DIFF
--- a/team-norms/retrospectives.md
+++ b/team-norms/retrospectives.md
@@ -137,4 +137,4 @@ The comradrospective facilitator should rotate so that everyone performs it.
 The format is expected to be evolutionary, this document serves as it’s living documentation. 
 
 * Some further reading is available on the [Retrospectives Wiki](http://retrospectivewiki.org/)
-* Some common [retrospective ailments & cures](index.php?title=Common_ailments_%26_cures)
+* Some common [retrospective ailments & cures](https://retrospectivewiki.org/index.php?title=Common_ailments_%26_cures)


### PR DESCRIPTION
**What?**
Fixes the link to the Common Ailments & Cures article on the Retrospectives Wiki

**Why?**
The link currently leads to a 404 page in GitHub