### PR TITLE
Create onboarding.md

### DIFF
--- a/guides/hiring/onboarding.md
+++ b/guides/hiring/onboarding.md
@@ -1,0 +1,23 @@
+# Onboarding 
+
+The Head of People conducts an onboarding session with all new starters. This includes:
+ - Issuing the new starter with their device (unless they have opted for BYOD)
+ - Registering that device on Charlie HR
+ - Setting up BPSS checks for the new starter (usually in advance of their first day)
+ - Ensuring the new starter is set up on, and understands, our internal SaaS solutions, such as (but not limited to): Harvest, Slack, G Suite, etc.
+ - Using The Made Tech Handbook to familiarise the new starter with Made Tech’s aims, objectives and procedures in general. 
+ - Setting up sessions with relevant departments (such as Operations, or Sales) and introducing the new starter to their line manager.
+
+## Probation Period
+There is a probation period of three or six months, depending on circumstances. 
+ - During this time, the new joiner will have a one-to-one with their line manager every two weeks. 
+ - At the end of the probation period the joiner will be informed they have: passed their probation, it will be extended, or they have not passed, in which case they will be released.
+ - Small Improvements is used to track an individual’s progress through their probation period. 
+
+## Security Checks 
+ - All team members are BPSS screened by our external partner agency, CB Screening.
+ - Some team members work on sensitive Public Sector systems and have been Security Cleared.
+ - We work with our clients to ensure our team have the necessary security clearance to perform their role
+
+## Contracts
+Employee contracts and other documentation are held in CharlieHR.


### PR DESCRIPTION
**What:**
An update on our onboarding process that covers who owns the responsibility for onboarding a new starter, what the process will involve, and how we security check all team members. 

**Why:**
Process not clearly outlined in handbook. There used to be a `first_day.md` file but it cannot be located (although it is referenced in some links).
We also need to provide this information in a clear, easy to access place for potential new employees, as well as for those going through the onboarding process so they know what to expect. 
This piece used to be part of a PR around IMS and was discussed with Yas (Head of people). It has now been edited and moved to the `Hiring` section as a more natural location for this information.