### PR TITLE
Create Confidentiality_Agreements

### DIFF
--- a/guides/security/confidentiality_agreements.md
+++ b/guides/security/confidentiality_agreements.md
@@ -1,13 +1,5 @@
-# Confidentiality Agreements
+# Confidentiality Agreements and NDAs
 
-At Made Tech:
- - All employees sign Terms and Conditions of Employment which include clauses for 
-   - Confidentiality
-   - Intellectual property
- - Company Non-Disclosure Agreements (NDA’s) are included in contracts raised with contractors 
- - Confidentiality requirements are also written into supplier contracts and agreements
- - Visitors are not allowed in areas where sensitive information is accessible unless they are working under a current NDA
- - No recording equipment may be used in internal, supplier, or customer meetings without the knowledge and consent of all those present in the meetings
- 
-## Terms & Conditions of Employment
-Confidentiality and security responsibilities are covered in the Contract of Employment and the Employee Handbook
+ - If clients ask about whether our team are covered by confidentiality agreements, we can let them know that all employees sign **Terms and Conditions of Employment** which include clauses for confidentiality and intellectual property.
+ - Company Non-Disclosure Agreements (NDA’s) are included in contracts raised with contractors. A template for our NDA can be found [here](https://docs.google.com/document/d/1YESByvaOv06azyq6JTNqmD9vsHh224lQ9urKV0p4_pY/edit)
+ - If you are looking to record or take photos of our team for any purpose, please remember that no recording equipment may be used in internal, supplier, or customer meetings without the **knowledge and consent** of all those present in the meetings

--- a/guides/security/confidentiality_agreements.md
+++ b/guides/security/confidentiality_agreements.md
@@ -1,0 +1,13 @@
+# Confidentiality Agreements
+
+At Made Tech:
+ - All employees sign Terms and Conditions of Employment which include clauses for 
+   - Confidentiality
+   - Intellectual property
+ - Company Non-Disclosure Agreements (NDA’s) are included in contracts raised with contractors 
+ - Confidentiality requirements are also written into supplier contracts and agreements
+ - Visitors are not allowed in areas where sensitive information is accessible unless they are working under a current NDA
+ - No recording equipment may be used in internal, supplier, or customer meetings without the knowledge and consent of all those present in the meetings
+ 
+## Terms & Conditions of Employment
+Confidentiality and security responsibilities are covered in the Contract of Employment and the Employee Handbook


### PR DESCRIPTION
**What:**
A short PR stating how Made Tech uses confidentiality agreements. 

**Why:**
It's very important to be clear and transparent around our use of confidentiality agreements. It not only ensures our team are handling information appropriately, but also instills confidence in our clients that Made tech is a safe and reliable partner to do business with. 

The use of NDAs for visitors also allows us to protect any sensitive work from falling into the wrong hands.