### PR TITLE
Create Chief Security Officer

### DIFF
--- a/roles/Chief_Security_Officer
+++ b/roles/Chief_Security_Officer
@@ -1,0 +1,19 @@
+# Chief Security Officer and Chief Quality Officer
+
+The CSO and CQO hold primary responsibility for assuring information security and quality in Made Tech.  
+These roles are both filled by the Chief Operating Officer.  
+Supported by the other Directors and the IMS Manager, the CSO / CQO is responsible for establishing an Integrated Management System that meets Company and client requirements.  
+Additionally, the CSO / CQO is responsible for:
+
+Ensuring appropriate financial and human resources are made available to maintain the IMS.
+
+- Reviewing the direction and progress of the IMS and authorising changes as necessary.
+- Keeping the IMS Management Team advised of any organisational changes/initiatives, which might impact the development and maintenance of the company IMS.
+- Supported by IMS Consultants and other members of the IMS Management Team, maintaining the company IMS including policy, objectives, organisation, responsibilities, resources, assets, access control, control processes and measures.
+- The effective Risk Assessment of company information assets.
+- Maintaining Made Tech Business Continuity Plans.
+- Monitoring client feedback and managing complaints
+- Reviewing and authorising IMS documentation for suitability and applicability.
+- Ensuring the IMS is integrated into all the Made Tech processes.
+- The initial point of escalation for issues
+


### PR DESCRIPTION
For Iso purposes, we are adding the role, or hat, of Chief Security Office. Probably less in need of traditional role expectations but here is the overview of the role