### PR TITLE
Reorganise and rename engineering roles

### DIFF
--- a/roles/README.md
+++ b/roles/README.md
@@ -9,13 +9,13 @@ looking for more responsibilities.
 
 ### Technology
 
-Engineering roles:
-
- - [Academy Software Engineer](academy_engineer.md)
- - [Software Engineer 1](engineer.md)
+ - [Academy Software Engineer](academy_software_engineer.md)
+ - [Software Engineer 1](software_engineer_1.md)
  - Software Engineer 2
- - [Senior Software Engineer 1](senior_engineer.md)
- - Senior Software Engineer 2 (previously [Lead Software Engineer](lead_engineer.md))
+ - [Senior Software Engineer 1](senior_software_engineer_1.md)
+ - [Senior Software Engineer 2](senior_software_engineer_2.md) – often advertised as Lead Software Engineer
+
+You may have also seen that we have people in Tech Lead and Tech Architect roles. These are hats worn by appropriate Senior 1 and 2s.
 
 ### Delivery
 

--- a/roles/academy_software_engineer.md
+++ b/roles/academy_software_engineer.md
@@ -1,6 +1,14 @@
-# Academy Engineer
+# Academy Software Engineer
 
-Our software delivery teams are the core of our business. They are usually comprised of a Lead Engineer, a Delivery Manager and one or more Engineers. As an Academy Engineer we expect someone:
+Being a software engineer at Made Tech is a great opportunity to surround yourself with people who care about the software they develop. Our 12 week Academy program gives you the skills you need to join one of our project delivery teams.
+
+## Who is it for?
+
+It's likely you will have already developed a love for programming, and you'll be convinced that a career in software development is where you want to go.
+
+You may have taught yourself to code, been on a course or two, or have a degree in Computer Science. You can stitch some code together, but probably have no commercial experience.
+
+[Find out more about our Academy programme.](https://www.madetech.com/careers/academy)
 
 ## Expectations
 
@@ -78,7 +86,7 @@ We expect our engineering team to own the whole process of getting working softw
 
 ### To be producing sensible lightweight release plans with an aim to get the thinnest slice possible in the hands of real users as quickly as possible, involving the team and stakeholders where appropriate.
 
-We expect our engineering team to actively form sensible strategies to get thin slices released to real users, and to have alignment on this strategy with the customer and with the team.
+We expect our engineering team to be actively form sensible strategies to get thin slices released to real users, and to have alignment on this strategy with the customer and with the team.
 
 ### To be able to turn user needs into actionable technical tasks that can be delivered incrementally
 

--- a/roles/senior_software_engineer_1.md
+++ b/roles/senior_software_engineer_1.md
@@ -1,4 +1,4 @@
-# Senior Engineer
+# Senior Software Engineer 1
 
 Our Senior Engineers combine technical excellence, drive to deliver, and coaching, to achieve outcomes for our customers and their users, and to establish strong engineering cultures within our customers organisations. They find themselves working on a variety of different problems from monoliths to microservices, upskilling colleagues and customers, always finding themselves learning from others, while constantly striving to be nice humans :)
 
@@ -131,7 +131,7 @@ We expect our Engineers to be able to work on entire features, from conception t
 
 
 
-### To be aware of political landscapes within client organisations and to be considerate of it. 
+### To be aware of political landscapes within client organisations and to be considerate of it.
 
 
 
@@ -151,7 +151,7 @@ We expect our engineering team to be friendly and lovely people to pair with. Al
 
 We expect our engineering team to keep their customers up to date with progress. Customers should be invited to standups or at appropriate points in time. A customer should never have to chase us for an update.
 
-### To be productive, in at least one programming language including a range of different tools that achieve the same goal in that language 
+### To be productive, in at least one programming language including a range of different tools that achieve the same goal in that language
 
 We expect our engineering team to understand that there are multiple tools available to achieve the same task at hand, and to explore these options in at least one language.
 

--- a/roles/senior_software_engineer_2.md
+++ b/roles/senior_software_engineer_2.md
@@ -1,39 +1,81 @@
-# Engineer
+# Senior Software Engineer 2
 
-Our Engineers build software that makes our customers happy, they prefer problem solving over task completing, love learning from colleagues, and constantly strive to be nice humans.
+(Often advertised as Lead Software Engineer.)
+
+Our Lead Engineers turn our customer’s needs into roadmaps, coach teams to deliver, are cutting the best code of their career, still learn every day, and constantly strive to be nice humans.
 
 ## What does the job entail?
 
-We primarily write and deliver custom software for the public sector. We work across central and local government, as well as in health, and our past lies in the technology startup world. Technical excellence for us isn’t about delivering to feature lists. We place a strong emphasis on outcome-based delivery; ensuring our customer’s goals are understood and achieved with the technology we deploy.
+We primarily write and deliver custom software to our customers. Before a project kicks off we will have a number of sessions where we begin to understand the customer’s business and what they are looking to achieve. We then formulate a roadmap for them, potentially a business case too, before starting delivery.
 
-Our teams have used Ruby with Rails and Sinatra, ES6 with React and Angular 2, C# with .NET Core. We don’t limit ourselves as a company and we expect all our Engineers to be keen on learning new technologies. Automation is important to our teams, so we make sure there is a CD pipeline set up to build, test, and release. Also, we will usually be responsible for setting up a customer’s infrastructure too! Such as on AWS, GCP or Azure using a tool like Terraform, though sometimes we opt for a Platform as a Service like Heroku.
+We build solutions in a variety of languages and platforms, historically Ruby on Rails, we tend to use React, JavaScript, Elixir, and Clojure these days. We will usually be responsible for setting up a customer’s infrastructure on AWS with tools like Ansible and Terraform though sometimes we opt for a Platform as a Service like Heroku. We make sure there is a Continuous Delivery pipeline running our automated test suites before deploying changes.
+
+The software we build solves business problems. We’ve built software for karaoke, e-commerce, retail buying departments, accountants, photography studios, warehouses, supply chain companies, and ourselves. Typical projects will last 3-6 months, some customers work with us over longer periods but we like to mix up teams at around 6 months to keep things fresh.
 
 ## What experience are we looking for?
 
-All of our Software Engineers are trained first as an [Academy Engineer](academy_engineer.md) within our 12 week Academy programme. We don't currently hire people into this role without them first going through our Academy.
+We’ll expect you to be a polyglot programmer versed in a mix of object and functional programming languages. We’d expect you to have some blog posts about your discipline, perhaps even a talk or two. Not only this but the right person would be adept in sharing their knowledge with others – we’d love to hear some examples of coaching and growing team members.
 
-## What we will provide you
+Every engineer at Made Tech is taught commercial responsibility and ownership over their software but it is expected to be second nature for this role.
 
-- Time to learn every Friday afternoon
-- Space to write blog posts regularly
-- Contribute to our culture and shape the way we work – even our handbook is open-sourced on Github
-- Regular lunch and socials with colleagues – we are vegan, halal, and non-drinker friendly, as well as meat-eater and drinker friendly
-- Retreats and trips with your colleagues every year
-- Paid holidays for your third and fifth anniversary working for us
-- Flexible holiday, working hours, and part-time
-- Generous parental leave and support
-- Season ticket loan
-- Cycle to work scheme, a place to secure your bike and a shower
-- Contributory pension scheme
-- Conference tickets and training
-- Volunteering time to help others get into the technology industry
+Further required experience:
+
+- Working directly with customers
+- Writing code with Test Driven Development
+- Pair programming as we pair around 50% of the time
+- Agile practices such as Scrum, XP, and/or Kanban
+- Working with a range of SQL and NoSQL databases
+- Infrastructure as code tools such as Ansible, Chef, Puppet, and/or Saltstack
+- Debugging a range of applications
+- Experience debugging infrastructure (AWS/Heroku/Linux/HTTP)
+- Strong delivery skills: a huge drive to get something shipped
+
+Everything else is optional but highly sought after. We would love you to have experience in:
+
+- Writing code with Acceptance Test Driven Development
+- Component based design techniques such as using pattern libraries, styled components, CSS-in-JS, BEM, and/or SUIT CSS
+- The React ecosystem including a TDD approach
+
+## What is it like to work at Made Tech?
+
+We are a sanctuary for those wanting to hone their skills alongside like-minded learners. After joining our team it is common for new starters to comment on how much they’re learning and how much they enjoy the fact they are surrounded by people they can learn from. This includes our most senior hires.
+
+The biggest thing you’ll take away from our culture after spending the day with us would be that we practice continuous improvement at every level. Everyone has peer-based one-to-ones every 2 weeks, along with monthly one-to-ones with a director. Teams have fortnightly retrospectives. We also hold a company wide retrospective fortnightly. We discuss our problems out in the open, and rather than punish failure we band together to find solutions.
+
+Other notable things:
+
+- Every Friday afternoon is dedicated to learning new skills
+- Everyone is encouraged to write blog posts regularly
+- Our handbook is open sourced
+- We are vegan and non-drinker friendly as well as meat-eater and drinker friendly
+- Retreats and trips every year
 
 ## Salary
 
-This role has a salary of £30-50k.
+This role has a salary of £65-85k depending on experience.
 
 
 ## Expectations
+
+### To be continuously providing sensible and well justified architectural guidance to teams, combining an understanding of the clients context, existing architectural landscape and the knowledge of the teams context, existing architectural landscape and the knowledge of the team
+
+
+
+### To be productive in a wide range of tooling, libraries and architectural styles
+
+
+
+### To continuously coach & mentor others to improve their lean and iterative approach to solving problems
+
+
+
+### To be productive in multiple paradigms of programming
+
+
+
+### To be leading the way with introducing new technologies to deliveries
+
+We expect our Senior Engineers to help teams use new technologies as part of deliveries. We expect them to make suggestions before new projects boot up and to help the adoption of the technology during the delivery through pairing and otherwise coaching their colleagues.
 
 ### To collaborate with Reliability Engineers as appropriate
 
@@ -50,10 +92,6 @@ We expect our Engineers to be able to work on entire features, from conception t
 ### To be able to build robust, maintainable interactive web-based frontends with an (appropriate amount of) focus on delivering a good user experience
 
 
-
-### To be working towards achieving the Made Tech Core Skills
-
-We expect our Engineers to be honing their craft, practising at every opportunity and consistently making progress towards attaining all the Made Tech Core Skills.
 
 ### To continuously seek out understanding of user needs and context, and contribute appropriate course corrections to plans throughout the delivery of software  
 
@@ -79,7 +117,11 @@ We expect our Engineers to be honing their craft, practising at every opportunit
 
 
 
-### To be aware of political landscapes within client organisations and to be considerate of it. 
+### To be able to apply appropriate strategies to deal with legacy code (code without tests)
+
+
+
+### To be aware of political landscapes within client organisations and to be considerate of it.
 
 
 
@@ -99,7 +141,7 @@ We expect our engineering team to be friendly and lovely people to pair with. Al
 
 We expect our engineering team to keep their customers up to date with progress. Customers should be invited to standups or at appropriate points in time. A customer should never have to chase us for an update.
 
-### To be productive, in at least one programming language including a range of different tools that achieve the same goal in that language 
+### To be productive, in at least one programming language including a range of different tools that achieve the same goal in that language
 
 We expect our engineering team to understand that there are multiple tools available to achieve the same task at hand, and to explore these options in at least one language.
 
@@ -154,6 +196,30 @@ We expect our engineering team to work as a team. That means we need our enginee
 ### To be continuously applying a lean and iterative approach to solving problems
 
 We expect our engineering team to embody a lean-mindset, solving problems by delivering early and often. We expect our engineers to actively seek out more effective ways to achieve this.
+
+### To act as a role model and servant leader to the team
+
+
+
+### To coach and nurture their team to improve their engineering and delivery capability
+
+We expect our Senior Engineers to proactively provide thoughtful and meaningful feedback for their team. A Senior Engineer is expected to spend time helping team members to improve their skills. A Senior Engineer is expected to identify and nurture candidates for Senior Engineer positions.
+
+### To lead workshop and roadmapping sessions to understand customer requirements and convert these in to deliverable iterations
+
+
+
+### To quickly become a trusted partner to the customer team, building a friendly relationship
+
+
+
+### To proactively identify opportunities where we can widen the impact of our work with the customer organisation
+
+
+
+### To make sensible, well reasoned commercial decisions
+
+
 
 ### To keep timesheets up-to-date and submitted before invoicing deadlines
 

--- a/roles/software_engineer_1.md
+++ b/roles/software_engineer_1.md
@@ -1,79 +1,39 @@
-# Lead Engineer
+# Software Engineer 1
 
-Our Lead Engineers turn our customer’s needs into roadmaps, coach teams to deliver, are cutting the best code of their career, still learn every day, and constantly strive to be nice humans.
+Our Engineers build software that makes our customers happy, they prefer problem solving over task completing, love learning from colleagues, and constantly strive to be nice humans.
 
 ## What does the job entail?
 
-We primarily write and deliver custom software to our customers. Before a project kicks off we will have a number of sessions where we begin to understand the customer’s business and what they are looking to achieve. We then formulate a roadmap for them, potentially a business case too, before starting delivery.
+We primarily write and deliver custom software for the public sector. We work across central and local government, as well as in health, and our past lies in the technology startup world. Technical excellence for us isn’t about delivering to feature lists. We place a strong emphasis on outcome-based delivery; ensuring our customer’s goals are understood and achieved with the technology we deploy.
 
-We build solutions in a variety of languages and platforms, historically Ruby on Rails, we tend to use React, JavaScript, Elixir, and Clojure these days. We will usually be responsible for setting up a customer’s infrastructure on AWS with tools like Ansible and Terraform though sometimes we opt for a Platform as a Service like Heroku. We make sure there is a Continuous Delivery pipeline running our automated test suites before deploying changes.
-
-The software we build solves business problems. We’ve built software for karaoke, e-commerce, retail buying departments, accountants, photography studios, warehouses, supply chain companies, and ourselves. Typical projects will last 3-6 months, some customers work with us over longer periods but we like to mix up teams at around 6 months to keep things fresh.
+Our teams have used Ruby with Rails and Sinatra, ES6 with React and Angular 2, C# with .NET Core. We don’t limit ourselves as a company and we expect all our Engineers to be keen on learning new technologies. Automation is important to our teams, so we make sure there is a CD pipeline set up to build, test, and release. Also, we will usually be responsible for setting up a customer’s infrastructure too! Such as on AWS, GCP or Azure using a tool like Terraform, though sometimes we opt for a Platform as a Service like Heroku.
 
 ## What experience are we looking for?
 
-We’ll expect you to be a polyglot programmer versed in a mix of object and functional programming languages. We’d expect you to have some blog posts about your discipline, perhaps even a talk or two. Not only this but the right person would be adept in sharing their knowledge with others – we’d love to hear some examples of coaching and growing team members.
+All of our Software Engineers are trained first as an [Academy Engineer](academy_engineer.md) within our 12 week Academy programme. We don't currently hire people into this role without them first going through our Academy.
 
-Every engineer at Made Tech is taught commercial responsibility and ownership over their software but it is expected to be second nature for this role.
+## What we will provide you
 
-Further required experience:
-
-- Working directly with customers
-- Writing code with Test Driven Development
-- Pair programming as we pair around 50% of the time
-- Agile practices such as Scrum, XP, and/or Kanban
-- Working with a range of SQL and NoSQL databases
-- Infrastructure as code tools such as Ansible, Chef, Puppet, and/or Saltstack
-- Debugging a range of applications
-- Experience debugging infrastructure (AWS/Heroku/Linux/HTTP)
-- Strong delivery skills: a huge drive to get something shipped
-
-Everything else is optional but highly sought after. We would love you to have experience in:
-
-- Writing code with Acceptance Test Driven Development
-- Component based design techniques such as using pattern libraries, styled components, CSS-in-JS, BEM, and/or SUIT CSS
-- The React ecosystem including a TDD approach
-
-## What is it like to work at Made Tech?
-
-We are a sanctuary for those wanting to hone their skills alongside like-minded learners. After joining our team it is common for new starters to comment on how much they’re learning and how much they enjoy the fact they are surrounded by people they can learn from. This includes our most senior hires.
-
-The biggest thing you’ll take away from our culture after spending the day with us would be that we practice continuous improvement at every level. Everyone has peer-based one-to-ones every 2 weeks, along with monthly one-to-ones with a director. Teams have fortnightly retrospectives. We also hold a company wide retrospective fortnightly. We discuss our problems out in the open, and rather than punish failure we band together to find solutions.
-
-Other notable things:
-
-- Every Friday afternoon is dedicated to learning new skills
-- Everyone is encouraged to write blog posts regularly
-- Our handbook is open sourced
-- We are vegan and non-drinker friendly as well as meat-eater and drinker friendly
-- Retreats and trips every year
+- Time to learn every Friday afternoon
+- Space to write blog posts regularly
+- Contribute to our culture and shape the way we work – even our handbook is open-sourced on Github
+- Regular lunch and socials with colleagues – we are vegan, halal, and non-drinker friendly, as well as meat-eater and drinker friendly
+- Retreats and trips with your colleagues every year
+- Paid holidays for your third and fifth anniversary working for us
+- Flexible holiday, working hours, and part-time
+- Generous parental leave and support
+- Season ticket loan
+- Cycle to work scheme, a place to secure your bike and a shower
+- Contributory pension scheme
+- Conference tickets and training
+- Volunteering time to help others get into the technology industry
 
 ## Salary
 
-This role has a salary of £65-85k depending on experience.
+This role has a salary of £30-40k.
 
 
 ## Expectations
-
-### To be continuously providing sensible and well justified architectural guidance to teams, combining an understanding of the clients context, existing architectural landscape and the knowledge of the teams context, existing architectural landscape and the knowledge of the team
-
-
-
-### To be productive in a wide range of tooling, libraries and architectural styles
-
-
-
-### To continuously coach & mentor others to improve their lean and iterative approach to solving problems
-
-
-
-### To be productive in multiple paradigms of programming
-
-
-
-### To be leading the way with introducing new technologies to deliveries
-
-We expect our Senior Engineers to help teams use new technologies as part of deliveries. We expect them to make suggestions before new projects boot up and to help the adoption of the technology during the delivery through pairing and otherwise coaching their colleagues.
 
 ### To collaborate with Reliability Engineers as appropriate
 
@@ -90,6 +50,10 @@ We expect our Engineers to be able to work on entire features, from conception t
 ### To be able to build robust, maintainable interactive web-based frontends with an (appropriate amount of) focus on delivering a good user experience
 
 
+
+### To be working towards achieving the Made Tech Core Skills
+
+We expect our Engineers to be honing their craft, practising at every opportunity and consistently making progress towards attaining all the Made Tech Core Skills.
 
 ### To continuously seek out understanding of user needs and context, and contribute appropriate course corrections to plans throughout the delivery of software  
 
@@ -115,11 +79,7 @@ We expect our Engineers to be able to work on entire features, from conception t
 
 
 
-### To be able to apply appropriate strategies to deal with legacy code (code without tests)
-
-
-
-### To be aware of political landscapes within client organisations and to be considerate of it. 
+### To be aware of political landscapes within client organisations and to be considerate of it.
 
 
 
@@ -139,7 +99,7 @@ We expect our engineering team to be friendly and lovely people to pair with. Al
 
 We expect our engineering team to keep their customers up to date with progress. Customers should be invited to standups or at appropriate points in time. A customer should never have to chase us for an update.
 
-### To be productive, in at least one programming language including a range of different tools that achieve the same goal in that language 
+### To be productive, in at least one programming language including a range of different tools that achieve the same goal in that language
 
 We expect our engineering team to understand that there are multiple tools available to achieve the same task at hand, and to explore these options in at least one language.
 
@@ -194,30 +154,6 @@ We expect our engineering team to work as a team. That means we need our enginee
 ### To be continuously applying a lean and iterative approach to solving problems
 
 We expect our engineering team to embody a lean-mindset, solving problems by delivering early and often. We expect our engineers to actively seek out more effective ways to achieve this.
-
-### To act as a role model and servant leader to the team
-
-
-
-### To coach and nurture their team to improve their engineering and delivery capability 
-
-We expect our Senior Engineers to proactively provide thoughtful and meaningful feedback for their team. A Senior Engineer is expected to spend time helping team members to improve their skills. A Senior Engineer is expected to identify and nurture candidates for Senior Engineer positions.
-
-### To lead workshop and roadmapping sessions to understand customer requirements and convert these in to deliverable iterations
-
-
-
-### To quickly become a trusted partner to the customer team, building a friendly relationship
-
-
-
-### To proactively identify opportunities where we can widen the impact of our work with the customer organisation
-
-
-
-### To make sensible, well reasoned commercial decisions
-
-
 
 ### To keep timesheets up-to-date and submitted before invoicing deadlines
 


### PR DESCRIPTION
## Why

We have a new SFIA-based role structure that we are rolling out. To be inline with SFIA levels, we now have Academy, Engineer 1, Engineer 2, Senior 1, and Senior 2 levels for engineering roles.

## What

Rename files and titles to match new role naming conventions.