### PR TITLE
Add Senior Eng with AWS

### DIFF
--- a/roles/senior_software_engineer_1_with_aws.md
+++ b/roles/senior_software_engineer_1_with_aws.md
@@ -1,0 +1,76 @@
+# Senior Software Engineer with strong AWS experience
+
+Bristol, UK.
+
+We are looking for Senior Engineers with a particular penchant and love for cloud, automation, slick tooling, and empowering software delivery by coaching teams in true DevOps fashion. While we are looking for those with significant experience working with AWS this role remains a full stack and polyglot role as with all of our Software Engineering roles.
+
+Our Senior Engineers combine technical excellence, drive to deliver, and coaching, to achieve outcomes for our customers and their users, and to establish strong engineering cultures within our customers organisations. They find themselves working on a variety of different problems from monoliths to microservices, upskilling colleagues and customers, always finding themselves learning from others, while constantly striving to be nice humans :)
+
+## What does the job entail?
+
+We primarily write and deliver custom software for the public sector. We work across central and local government, as well as in health, and our past lies in the technology startup world. Technical excellence for us isn’t about delivering to feature lists. We place a strong emphasis on outcome-based delivery; ensuring our customer’s goals are understood and achieved with the technology we deploy.
+
+High performing software delivery teams need to be empowered to iteratively and rapidly deliver changes all the way through to production. To do this we combine our extensive cloud automation knowledge with DevOps culture.
+
+We've been using AWS from the start and as Advanced Partners are go to experts within the public sector. We use a range of IaaS, PaaS and FaaS depending on the needs of our users, in this case software teams, such as EC2, ECS, Kubernetes, Heroku, CloudFoundry, Azure App Services, and more. We ensure we document our architecture and infrastructure as code, using technologies such as Terraform and OpenAPI. Containerisation is a big part of empowering our teams to develop, deploy and scale their applications, but so too is using AWS Lambda and avoiding the complexity of stateful services altogther. Right tool for the job.
+
+For us, DevOps is about culture rather than roles and titles. Even though this role is for someone with strong DevOps experience, the biggest impact you will have is coaching and helping teams use the platforms you build. You won't be building infrastructure in isolation or charged with deploying other peoples work into production. You'll empower teams with the mantra: you build it, you run it!
+
+Our teams have used Ruby with Rails and Sinatra, ES6 with React and Angular 2, C# with .NET Core. We don’t limit ourselves as a company and we expect all our Engineers to be keen on learning new technologies. Automation is important to our teams, so we make sure there is a CD pipeline set up to build, test, and release many times per day.
+
+We grow a team of polyglot programmers, which you might already consider yourself to be, who are versed in a mix of paradigms such as object-oriented, functional, declarative, event-based and aspect-oriented. To create this environment our Senior Engineers need to embrace sharing their knowledge and skills with others, and they need to keep an open mind – we’d love to hear some examples of mentoring, coaching and growing team members. Maybe you will have written some blog posts about your discipline, or perhaps even delivered a talk or two.
+
+## What experience are we looking for?
+
+While we will look for you to have experience in these things, if you don’t have one of these don’t let that stop you applying.
+
+- 5+ years working with AWS
+- Written code with tests
+- Delivered in an agile environment
+- Worked with more than one programming language
+- Worked with databases
+- Worked with APIs
+- Debugging experience in a range of systems
+- Evidence of self-development – we value keen learners
+- Drive to deliver outcomes for users
+- Desire to mentor others
+- Empathy and people skills
+
+## Optional experience
+
+Don’t forget to mention any of the experience listed below. While it’s optional, it’s all highly desired!
+
+- Consultancy
+- Working directly with customers and users
+- Working within multidisciplinary teams with product, design, and technology working within the same cycles
+- Showcasing and presentation skills
+- Agile practices such as Scrum, XP, and/or Kanban
+- Pair programming – we pair around 50% of the time
+- Writing code with test-driven development
+- Component-based design techniques such as using pattern libraries, styled-components, CSS-in-JS, BEM, and/or SUIT CSS
+- Debugging infrastructure (AWS/Heroku/Linux/HTTP, GCP and Azure)
+- The React ecosystem including a test-driven approach
+- Infrastructure as code tools such as Ansible, Chef, Puppet, Terraform and/or Saltstack
+- Familiarity with architectural and design patterns
+- Use of architectural decision records
+- Writing blog posts and giving talks
+
+## What we will provide you
+
+- Time to learn every Friday afternoon
+- Space to write blog posts regularly
+- Contribute to our culture and shape the way we work – even our handbook is open-sourced on Github
+- Regular lunch and socials with colleagues – we are vegan, halal, and non-drinker friendly, as well as meat-eater and drinker friendly
+- Retreats and trips with your colleagues every year
+- Paid holidays for your third and fifth anniversary working for us
+- Flexible holiday, working hours, and part-time
+- Generous parental leave and support
+- Season ticket loan
+- Cycle to work scheme, a place to secure your bike and a shower
+- Contributory pension scheme
+- Conference tickets and training
+- Volunteering time to help others get into the technology industry
+
+## Salary
+
+This role has a salary of £40-60k depending on experience.


### PR DESCRIPTION
## What

Adding a Senior Engineer job advert with the requirement of strong AWS experience. While this job advert has a specific need for strong AWS experience, it’s for our standard Senior Engineer role. We aren’t moving away from our polyglot / generalist approach.

## Why

We have a specific need in Bristol over the next two years for AWS skills and so need to advertise for that particular skillset.

Anyone we hire needs to be a full stack / polyglot software engineer, or at least want to be long term.