### PR TITLE
Add link to AWS specific role from roles/README

### DIFF
--- a/roles/README.md
+++ b/roles/README.md
@@ -12,7 +12,7 @@ looking for more responsibilities.
  - [Academy Software Engineer](academy_software_engineer.md)
  - [Software Engineer 1](software_engineer_1.md)
  - Software Engineer 2
- - [Senior Software Engineer 1](senior_software_engineer_1.md)
+ - [Senior Software Engineer 1](senior_software_engineer_1.md) – also looking for strong AWS experience for a [full stack role in Bristol](senior_software_engineer_1_with_aws.md)
  - [Senior Software Engineer 2](senior_software_engineer_2.md) – often advertised as Lead Software Engineer
 
 You may have also seen that we have people in Tech Lead and Tech Architect roles. These are hats worn by appropriate Senior 1 and 2s.


### PR DESCRIPTION
## What

Add a link from roles/README to senior engineer role with AWS experience.

## Why

So that people can stumble upon the role if they are reading our Handbook. It's also good to have all roles published in our Handbook for transparency reasons (not least salary!)