### PR TITLE
Update Senior 1 and Senior 2 to be consistent with AWS role

### DIFF
--- a/roles/senior_software_engineer_1.md
+++ b/roles/senior_software_engineer_1.md
@@ -8,7 +8,15 @@ Our Senior Engineers combine technical excellence, drive to deliver, and coachin
 
 We primarily write and deliver custom software for the public sector. We work across central and local government, as well as in health, and our past lies in the technology startup world. Technical excellence for us isn’t about delivering to feature lists. We place a strong emphasis on outcome-based delivery; ensuring our customer’s goals are understood and achieved with the technology we deploy.
 
-Our teams have used Ruby with Rails and Sinatra, ES6 with React and Angular 2, C# with .NET Core. We don’t limit ourselves as a company and we expect all our Engineers to be keen on learning new technologies. Automation is important to our teams, so we make sure there is a CD pipeline set up to build, test, and release. Also, we will usually be responsible for setting up a customer’s infrastructure too! Such as on AWS, GCP or Azure using a tool like Terraform, though sometimes we opt for a Platform as a Service like Heroku.
+Our teams have used Ruby with Rails and Sinatra, ES6 with React and Angular 2, C# with .NET Core. We don’t limit ourselves as a company and we expect all our Engineers to be keen on learning new technologies. Automation is important to our teams, so we make sure there is a CD pipeline set up to build, test, and release many times per day.
+
+High performing software delivery teams need to be empowered to iteratively and rapidly deliver changes all the way through to production. To do this we combine our extensive cloud automation knowledge with DevOps culture.
+
+We've been using AWS from the start and as Advanced Partners are go to experts within the public sector. We use a range of IaaS, PaaS and FaaS depending on the needs of our users, in this case software teams, such as EC2, Lambda, ECS, Kubernetes, Heroku, CloudFoundry, Azure App Services, and more. We use VPC and PrivateLink for connecting to on-premise, legacy systems. We also use API Gateway, S3, CloudFront, SQS, SNS, SES, RDS, and many other services provided by AWS.
+
+We ensure we document our architecture and infrastructure as code, using technologies such as Terraform and OpenAPI. Containerisation is a big part of empowering our teams to develop, deploy and scale their applications, but so too is using AWS Lambda and avoiding the complexity of stateful services altogether. Right tool for the job.
+
+For us, DevOps is about culture rather than roles and titles. Even though this role is for someone with strong DevOps experience, the biggest impact you will have is coaching and helping teams use the platforms you build. You won't be building infrastructure in isolation or charged with deploying other peoples work into production. You'll empower teams with the mantra: you build it, you run it!
 
 We grow a team of polyglot programmers, which you might already consider yourself to be, who are versed in a mix of paradigms such as object-oriented, functional, declarative, event-based and aspect-oriented. To create this environment our Senior Engineers need to embrace sharing their knowledge and skills with others, and they need to keep an open mind – we’d love to hear some examples of mentoring, coaching and growing team members. Maybe you will have written some blog posts about your discipline, or perhaps even delivered a talk or two.
 

--- a/roles/senior_software_engineer_1.md
+++ b/roles/senior_software_engineer_1.md
@@ -1,5 +1,7 @@
 # Senior Software Engineer 1
 
+Manchester & London, UK.
+
 Our Senior Engineers combine technical excellence, drive to deliver, and coaching, to achieve outcomes for our customers and their users, and to establish strong engineering cultures within our customers organisations. They find themselves working on a variety of different problems from monoliths to microservices, upskilling colleagues and customers, always finding themselves learning from others, while constantly striving to be nice humans :)
 
 ## What does the job entail?

--- a/roles/senior_software_engineer_1.md
+++ b/roles/senior_software_engineer_1.md
@@ -39,9 +39,9 @@ Don’t forget to mention any of the experience listed below. While it’s optio
 - Pair programming – we pair around 50% of the time
 - Writing code with test-driven development
 - Component-based design techniques such as using pattern libraries, styled-components, CSS-in-JS, BEM, and/or SUIT CSS
-- Debugging infrastructure (AWS/Heroku/Linux/HTTP, GCP and Azure)
+- Debugging infrastructure
 - The React ecosystem including a test-driven approach
-- Infrastructure as code tools such as Ansible, Chef, Puppet, Terraform and/or Saltstack
+- Infrastructure as code technology like Terraform and Cloud Formation
 - Familiarity with architectural and design patterns
 - Use of architectural decision records
 - Writing blog posts and giving talks

--- a/roles/senior_software_engineer_2.md
+++ b/roles/senior_software_engineer_2.md
@@ -10,7 +10,15 @@ We primarily write and deliver custom software to our customers. Before a projec
 
 We primarily write and deliver custom software for the public sector. We work across central and local government, as well as in health, and our past lies in the technology startup world. Technical excellence for us isn’t about delivering to feature lists. We place a strong emphasis on outcome-based delivery; ensuring our customer’s goals are understood and achieved with the technology we deploy.
 
-Our teams have used Ruby with Rails and Sinatra, ES6 with React and Angular 2, C# with .NET Core. We don’t limit ourselves as a company and we expect all our Engineers to be keen on learning new technologies. Automation is important to our teams, so we make sure there is a CD pipeline set up to build, test, and release. Also, we will usually be responsible for setting up a customer’s infrastructure too! Such as on AWS, GCP or Azure using a tool like Terraform, though sometimes we opt for a Platform as a Service like Heroku.
+Our teams have used Ruby with Rails and Sinatra, ES6 with React and Angular 2, C# with .NET Core. We don’t limit ourselves as a company and we expect all our Engineers to be keen on learning new technologies. Automation is important to our teams, so we make sure there is a CD pipeline set up to build, test, and release many times per day.
+
+High performing software delivery teams need to be empowered to iteratively and rapidly deliver changes all the way through to production. To do this we combine our extensive cloud automation knowledge with DevOps culture.
+
+We've been using AWS from the start and as Advanced Partners are go to experts within the public sector. We use a range of IaaS, PaaS and FaaS depending on the needs of our users, in this case software teams, such as EC2, Lambda, ECS, Kubernetes, Heroku, CloudFoundry, Azure App Services, and more. We use VPC and PrivateLink for connecting to on-premise, legacy systems. We also use API Gateway, S3, CloudFront, SQS, SNS, SES, RDS, and many other services provided by AWS.
+
+We ensure we document our architecture and infrastructure as code, using technologies such as Terraform and OpenAPI. Containerisation is a big part of empowering our teams to develop, deploy and scale their applications, but so too is using AWS Lambda and avoiding the complexity of stateful services altogether. Right tool for the job.
+
+For us, DevOps is about culture rather than roles and titles. Even though this role is for someone with strong DevOps experience, the biggest impact you will have is coaching and helping teams use the platforms you build. You won't be building infrastructure in isolation or charged with deploying other peoples work into production. You'll empower teams with the mantra: you build it, you run it!
 
 We grow a team of polyglot programmers, which you might already consider yourself to be, who are versed in a mix of paradigms such as object-oriented, functional, declarative, event-based and aspect-oriented. To create this environment our Senior Engineers need to embrace sharing their knowledge and skills with others, and they need to keep an open mind – we’d love to hear some examples of mentoring, coaching and growing team members. Maybe you will have written some blog posts about your discipline, or perhaps even delivered a talk or two.
 

--- a/roles/senior_software_engineer_2.md
+++ b/roles/senior_software_engineer_2.md
@@ -38,9 +38,9 @@ Don’t forget to mention any of the experience listed below. While it’s optio
 - Consultancy
 - Pair programming – we pair around 50% of the time
 - Component-based design techniques such as using pattern libraries, styled-components, CSS-in-JS, BEM, and/or SUIT CSS
-- Debugging infrastructure (AWS/Heroku/Linux/HTTP, GCP and Azure)
+- Debugging infrastructure
 - The React ecosystem including a test-driven approach
-- Infrastructure as code tools such as Ansible, Chef, Puppet, Terraform and/or Saltstack
+- Infrastructure as code technology like Terraform and Cloud Formation
 - Use of architectural decision records
 - Writing blog posts and giving talks
 

--- a/roles/senior_software_engineer_2.md
+++ b/roles/senior_software_engineer_2.md
@@ -16,6 +16,8 @@ We grow a team of polyglot programmers, which you might already consider yoursel
 
 ## What experience are we looking for?
 
+While we will look for you to have experience in these things, if you don’t have one of these don’t let that stop you applying.
+
 - Working directly with customers and users
 - Working within multidisciplinary teams with product, design, and technology working within the same cycles
 - Agile practices such as Scrum, XP, and/or Kanban

--- a/roles/senior_software_engineer_2.md
+++ b/roles/senior_software_engineer_2.md
@@ -1,6 +1,6 @@
 # Senior Software Engineer 2
 
-(Often advertised as Lead Software Engineer.)
+Manchester & London, UK. Often advertised as Lead Software Engineer.
 
 Our Senior Engineer 2s turn our customer’s needs into roadmaps, coach teams to deliver, are cutting the best code of their career, still learn every day, and constantly strive to be nice humans.
 


### PR DESCRIPTION
## What

Update all senior engineer roles to be consistent:

- Add location
- Update "experience we are looking" for across roles so wording is the same
- Be nice, even for the Senior 2 role 😄(see 3c5d0dd)
- Add DevOps details to all senior roles

## Why

Yesterday I added the Senior 1 role for Bristol with specific AWS experience needed. Some of these updates should apply more generally to all our senior roles.