### PR TITLE
Update learning pages to be inclusive and explain current Learn Tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Contributing to the handbook isn't only possible for `git` users, find steps to 
 
 * [About Made Tech](company/about.md)
 * [Welcome Pack](company/welcome_pack.md)
-* [Learning](learning/readme.md) (Engineering)
+* [Learning](learning/readme.md)
 
 ### Roles
 

--- a/learning/readme.md
+++ b/learning/readme.md
@@ -1,6 +1,25 @@
-# Learning (Engineering roles)
+# Learning
 
-## Onboarding
+## Learn Tech
+
+Every Friday between 13:30 and 17:00 the team come together to focus on learning new or developing existing skills.
+
+Learn Tech consists of a number of tracks, where the whole company learn everything we need to know to make Made Tech an even more brilliant team. Tracks will run periodically throughout the year, between which more free-form learn tech sessions or personal development will take place.
+
+* All permanent employees are expected to attend and be on time.
+* The time should be focussed on attaining, or be defining and/or improving skills relevant to your role at Made Tech.
+
+## Showcases
+
+Showcases are more free-form - between 16:30 and 17:00 there is an opportunity to present to the team.
+
+Use this as an opportunity to share with the wider group something of interest.
+
+This could be, for example, how you applied TDD discipline on your delivery team, or it could be how you approached infrastructure as code at your previous company.
+
+## Engineer roles
+
+### Onboarding
 
 Before joining a delivery team, you will spend some time with a mentor focussing on skills relevant to delivery teams.
 
@@ -13,28 +32,10 @@ As a high level summary, we will cover the following -
 5. Discuss the SOLID principles with a mentor, with reference to Clean Architecture and (A)TDD.
 6. Be introduced to the [Tic Tac Toe sparring exercise](https://learn.madetech.com/sparring/tic-tac-toe/)
 
-## Core Skills
+### Core Skills
 
 Our Engineering team has built some Core Skills, which are courses around topics valuable to Made Tech.
 
 Currently, each Core Skill is comprised of 3 levels, with acompanying stickers (which you will see on people's laptops).
 
 You earn these stickers by doing coursework, or by passing an assessment, set by members of the Engineering team with expertise in that skill.
-
-### Learn Tech
-
-Every Friday between 13:30 and 17:00 the team come together to focus on Core Skills.
-
-There are two teams, each with their own standup. Details can be found in [this spreadsheet](https://docs.google.com/spreadsheets/d/1ZUCmchTJnIymhUn_B_iZIYPLPz476PfaZ5KlZ_Gjd1s/edit#gid=27390006) along with a record of assessments.
-
-* All Permanent Engineers are expected to attend and be on time.
-* The time should be focussed on attaining, or be defining and/or improving Core Skills.
-
-### Show & Tell
-
-Show & Tell is more freeform - between 16:30 and 17:00 there is an opportunity to present to the team.
-
-Use this as an opportunity to share with the wider group something of interest.
-
-This could be, for example, how you applied TDD discipline on your delivery team, or it could be how you approached infrastructure as code at your previous company.
-


### PR DESCRIPTION
As I'm new I hope I got everything correct. I have one question that might improve the page though:

- How many and what are the tracks in Made Tech (I looked but couldn't see a list of tracks in any emails or slack messages)

## Commit message:

Following feedback in issue #318 the handbook suggested that Learn Tech
was for Engineering staff only, which is completely wrong.

This led to realising that the handbook also referenced old Learn Tech
and even including a spreadsheet that included some fairly old data.

Even though engineers are important (no more important than anyone else in
the company though!), the specific learn tech and onboarding rather than
being worthy of being the first thing on the page, and the mentioned
activities are more of an exception to regular staff activities, I moved
them further down the order of information.