### PR TITLE
Fix broken links and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,7 @@ Contributing to the handbook isn't only possible for `git` users, find steps to 
 #### Team
 
 * [Team Norms](team-norms)
-* [SRE Team Field Guide](https://github.com/madetech/SRE-team-field-guide)
-* [Sales Handbook](https://github.com/madetech/sales-handbook)
 * [Marketing Assets](https://github.com/madetech/marketing-assets)
-* [Blogging at Made Tech](https://github.com/madetech/blog)
 * [3rd Party Expenses](guides/3rd_party_services.md)
 * [VPN](guides/vpn)
 * [WiFi](guides/wifi)
@@ -95,7 +92,6 @@ Contributing to the handbook isn't only possible for `git` users, find steps to 
 * [Acceptable Usage Policy](guides/security/acceptable_use_policy.md)
 * [BYOD Policy](guides/security/bring_your_own_device.md)
 * [Device profiles](guides/security/device_profiles.md)
-* [Server Security](guides/security/server_setup_guidelines.md)
 * [What To Do If Your Device Is Lost Or Stolen](guides/security/lost_or_stolen.md)
 * [Last Day](guides/security/last_day.md)
 * [Office Visitors](guides/security/office_visitors.md)

--- a/benefits/remote_working.md
+++ b/benefits/remote_working.md
@@ -2,28 +2,28 @@
 
 We feel it's important that we provide the flexibility for people to work wherever they feel productive and happy. Be that in the office, remotely at home, or from a coffee shop. We acknowledge that working remotely can lead to increased productivity, and have positive effects on wellbeing.
 
-There are tradeoffs when choosing between working from the office and from home. Below is some general ettiquette for occasional remote work, along with guidelines for working remotely on a regular basis.
+There are tradeoffs when choosing between working from the office and from home. Below is some general etiquette for occasional remote work, along with guidelines for working remotely on a regular basis.
 
 ### Occasional Remote Working
 - Check and clear any remote work with the rest of your team before the end of the previous working day
 - Ensure your absence does not negatively impact the productivity and/or success of other team members
-- Once agreed with your team and customers add time off as 'Working from home' in Charlie HR 
+- Once agreed with your team and customers add time off as 'Working from home' in Charlie HR
 - Check that you're not needed on-site by a customer or your team
 - Ensure you're available for your team ceremonies as normal, and are able to dial in without interruption
-- Be a good Slack citizen and check in regularly and visbily with your team throughout the working day in public channels
+- Be a good Slack citizen and check in regularly and visibly with your team throughout the working day in public channels
 - Ensure you're clear on your workload for the day or days you wish to work from home and ensure that you won't benefit from working closely with others
 - Ensure you're not scheduled for any meetings or sessions
-- Barring any extraordinary circumstances, we like people to be in the office on Friday for [lunch](/benefits/friday_lunch.md) and Learn Tech
+- Barring any extraordinary circumstances, we like people to be in the office on Friday for [lunch](friday_lunch.md) and Learn Tech
 
 ### Regular Remote Working
 
 There are some additional considerations when working from home regularly
 
-- Talk to your team ahead of committing yourself to working remotely on a regular basis. Team members on Delivery should check in with the Delivery Lead. Members of business teams should check with their Head of Department. 
+- Talk to your team ahead of committing yourself to working remotely on a regular basis. Team members on Delivery should check in with the Delivery Lead. Members of business teams should check with their Head of Department.
 - Once agreed, put a recurring event in Charlie HR
 - We recommend remote working on a recurring basis a maximum of 2 days per week when part of a delivery team to ensure you don't lose context.
 - Make sure you choose days that will have the least impact on customers. A larger organisation's time will be less flexible and you'll need to ensure there are clearly set expectations around when showcases will be etc.
-- It is also important to ensure that a regular absence doesn't impact the productivity and success of other team members (such as a pairing partner), or interrupt the flow of regular team ceremonies. 
+- It is also important to ensure that a regular absence doesn't impact the productivity and success of other team members (such as a pairing partner), or interrupt the flow of regular team ceremonies.
 
 ### Refusing a Request for Remote Working
 
@@ -37,5 +37,5 @@ All requests to work from home should be considered in their individual circumst
 
 When remote working, and when onsite with a client, it is important to pay close attention to these security guidelines in addition to your normal security practices:
 
-- If you are in a public place, such as a coffee shop, make sure you are handling any sensitive data responsibly and securely. Can you be overseen? Is your connection secure? 
+- If you are in a public place, such as a coffee shop, make sure you are handling any sensitive data responsibly and securely. Can you be overseen? Is your connection secure?
  - Ensure any work-related conversations can’t be overheard. If that’s not possible, try to talk in general terms, and without specific details such as names or clients.

--- a/benefits/working_hours.md
+++ b/benefits/working_hours.md
@@ -8,7 +8,7 @@ Some things to note:
 
  - We do not have a specific start time but we do have our All Hands Mondays and Fridays at 0950, and Wednesdays at 0930, so you should get into the office or dial in before that time in our #announcements Slack channel.
 
- - Likewise there isn't a time we expect everyone to leave the office. Of course if you're leaving at 1630 every day and are having problems delivering on your commitments someone will likely provide you with [feedback](https://github.com/madetech/handbook/blob/working_hours/policies/continuous_feedback.md) to help improve things.
+ - Likewise there isn't a time we expect everyone to leave the office. Of course if you're leaving at 1630 every day and are having problems delivering on your commitments someone will likely provide you with feedback to help improve things.
 
  - Pressure can creep in around deadlines and sometimes staying late to ensure a smooth launch or to help diagnose and fix a problem is a necessity. However these occassions should be very rare. If you regularly feel this pressure, say more than twice a year then speak to a colleague.
 

--- a/company/welcome_pack.md
+++ b/company/welcome_pack.md
@@ -34,7 +34,7 @@ Our on-boarding checklist is hosted on airtable. You will receive a link to your
 * [ ] Understand how weekly shop works and how to ask for office supplies
 * [ ] Office keys (if applicable)
 * [ ] Read the [Security Policy](../guides/security/security_policy.md), [Acceptable Use Policy](../guides/security/acceptable_use_policy.md) & [Bring Your Own Device Policy](../guides/security/bring_your_own_device.md)
-* [ ] Ensure devices used for [work are secure](../guides/security/protect_the_company.md)
+* [ ] Ensure your own devices used for [work are secure](../guides/security/bring_your_own_device.md)
 * [ ] Get added to team@madetech.com mailing list
 * [ ] Set up Slack account with picture, name(s), name pronunciation guide and [pronouns](https://www.mypronouns.org/)
 * [ ] Enrollment to Baseline Personnel Security Standard (BPSS)
@@ -67,9 +67,7 @@ Academy Engineers: you can skip these two for now, but you will probably need th
 #### Sales & Marketing
 
 * [ ] HubSpot
-* [ ] Access to [Sales Handbook](https://github.com/madetech/sales-handbook)
 * [ ] Access to [LinkedIn Sales Navigator](https://www.linkedin.com/sales/)
-* [ ] Trello Sales Boards e.g. [Sales 2018](https://trello.com/b/r2JnD6Nm/sales-2018)
 
 #### Engineers
 

--- a/guides/welfare/parental_leave.md
+++ b/guides/welfare/parental_leave.md
@@ -38,6 +38,6 @@ The rules around SPL are fairly complex, government guidelines are available her
 
 ## Other Considerations
 
-We offer a number of additional company benefits which may be attractive to new parents, including [Remote Working](/benefits/remote_working.md), [Untracked Holiday Allowance](/benefits/untracked_holiday.md), [Flexible Work Weeks](/benefits/flexible_working.md) and [Flexible Working Hours](/benefits/working_hours.md). 
+We offer a number of additional company benefits which may be attractive to new parents, including [Remote Working](../../benefits/remote_working.md), [Untracked Holiday Allowance](../../benefits/flexible_holiday.md), [Flexible Work Weeks](../../benefits/flexible_working.md) and [Flexible Working Hours](../../benefits/working_hours.md). 
 
 _Note: There is a strong desire to improve our offering, though we're currently constrained by our company size. As we grow and get a larger team and turnover, we're expecting to be able to make a more attractive package available_

--- a/team-norms/retrospectives.md
+++ b/team-norms/retrospectives.md
@@ -26,7 +26,7 @@ There are two elements to retrospectives:
 Retrospectives should occur at least once every two weeks and should normally take 30-60 minutes but can be flexible depending on team size; for instance Academy Retrospectives have a 90 minute timebox.
 Comradrospectives are scheduled every 2 weeks on Friday for 60 minutes.
 
-### Purpose 
+### Purpose
 
 The purpose of retrospectives is to:
 
@@ -49,7 +49,7 @@ Remember that action points are only potential solutions to a problem. In order 
 
 Sometimes it is not immediately obvious how to solve a problem that the team is collectively facing. In these situations it may be wise to have the team attempt to resolve a particularly pressing pain point during normal working time.
 
-Similar to action points, it’s important that the team is able to measure and sense check whether it has made progress towards some goal. 
+Similar to action points, it’s important that the team is able to measure and sense check whether it has made progress towards some goal.
 
 Make sure the team has awareness on what the outcome of potential solutions would look like.
 
@@ -93,7 +93,7 @@ If the safety level has increased after this point, then you can run the retrosp
 
 Six Thinking Hats is a good discipline for everybody to get the most out of your retrospective experience.
 
-Ensuring that everyone in the retrospective only focusses on one hat at a time, can keep the discussions aligned towards a common direction. 
+Ensuring that everyone in the retrospective only focusses on one hat at a time, can keep the discussions aligned towards a common direction.
 
 A common order to move through the hats is:
 
@@ -134,7 +134,7 @@ The comradrospective facilitator should rotate so that everyone performs it.
 
 ### Notes
 
-The format is expected to be evolutionary, this document serves as it’s living documentation. 
+The format is expected to be evolutionary, this document serves as it’s living documentation.
 
-* Some further reading is available on the [Retrospectives Wiki](http://retrospectivewiki.org/)
+* Some further reading is available on the [Retrospectives Wiki](/index.php?title=Agile_Retrospective_Resource_Wiki)
 * Some common [retrospective ailments & cures](https://retrospectivewiki.org/index.php?title=Common_ailments_%26_cures)


### PR DESCRIPTION
## What

This change removes links that either 404’d or in the case of Sales Handbook have not been maintained since 2018.

## Why

I noticed broken links! Links should work, we want to provide a good user experience to users of our Handbook. Also see #296.