### PR TITLE
Usability updates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Contributing to the handbook isn't only possible for `git` users, find steps to 
 
 ### Introduction to Made Tech
 
-* [About Made Tech](company/about.md)
-* [Welcome Pack](company/welcome_pack.md)
+* [About Made Tech](company/about.md) – Why we do what we do
+* [Welcome Pack](company/welcome_pack.md) – All you need to know when joining  Made Tech
 
 ### Roles
 
-* [About Roles](roles/README.md)
-* [All Roles](roles/)
+* [About Roles](roles/README.md) – Overview of our roles
+* [All Roles](roles/) – Directory of roles
 
 ### Benefits & Perks
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Contributing to the handbook isn't only possible for `git` users, find steps to 
 
 * [About Made Tech](company/about.md)
 * [Welcome Pack](company/welcome_pack.md)
-* [Learning](learning/readme.md)
 
 ### Roles
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 At Made Tech, we're building an open and transparent company, full of people who love their work and enjoy the challenges they face every day. To do this, we want everyone to understand what is expected of them, the things we value and the things we believe should be avoided.
 
-This handbook should be the starting point for any new team members. It provides an overview of [why we exist](company/about.md), our roles, our investment into staff welfare, our team norms, and details of our processes, policies and benefits.
+This Handbook should be the starting point for any new team members. It provides an overview of [why we exist](company/about.md), our roles, our investment into staff welfare, our team norms, and details of our processes, policies and benefits.
 
-## Contributing to our handbook
+## Contributing to our Handbook
 
 We're a company that moves fast, so we're going to need everyone to help us keep this up to date. If you encounter something that you think should be in this Handbook or spot a typo, please feel free to [open a pull request](https://github.com/madetech/handbook/pulls). If you have a question feel free to [open an issue](https://github.com/madetech/handbook/issues). This applies whether you're a Made Tech employee or not :)
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ This handbook should be the starting point for any new team members. It provides
 
 We're a company that moves fast, so we're going to need everyone to help us keep this up to date. If you encounter something that you think should be in this Handbook or spot a typo, please feel free to [open a pull request](https://github.com/madetech/handbook/pulls). If you have a question feel free to [open an issue](https://github.com/madetech/handbook/issues). This applies whether you're a Made Tech employee or not :)
 
-### Using the Github user interface
-
-Contributing to the handbook isn't only possible for `git` users, find steps to [create pages through the Github user interface here](guides/contributing_to_the_handbook.md).
+For more information on contributing, including how to as a non-technical user, read our [CONTRIBUTING.md](guides/contributing_to_the_handbook.md).
 
 ## Table of contents
 


### PR DESCRIPTION
## What

- Remove “Learning” from Introduction to Made Tech
- Add descriptions to links in README
- Reduce information about contributing in README
- Use Handbook rather than handbook

## Why

Improve usability of Handbook README by:
 - Making it easier to get to table of contents
 - Providing more information about links