### PR TITLE
Remove # of years experience from role requirement

### DIFF
--- a/roles/senior_software_engineer_1_with_aws.md
+++ b/roles/senior_software_engineer_1_with_aws.md
@@ -26,7 +26,7 @@ We grow a team of polyglot programmers, which you might already consider yoursel
 
 While we will look for you to have experience in these things, if you don’t have one of these don’t let that stop you applying.
 
-- 5+ years working with AWS
+- Deep working knowledge of developing and maintaining AWS infrastructure
 - Written code with tests
 - Delivered in an agile environment
 - Worked with more than one programming language


### PR DESCRIPTION
## What

Remove # of years experience from role requirement.

## Why

Years !== quality, like lines of code. We are looking for deepened and practical experience. Hopefully this is clearer and help people self-select better.