### PR TITLE
Correct URL & reword link to Michael Nygard's blog post on ADRs

### DIFF
--- a/team-norms/development_practices.md
+++ b/team-norms/development_practices.md
@@ -37,4 +37,4 @@ Be sure to communicate effectively. Asking too many questions is much preferred 
 
 ADR's are a formal way of documenting the decision-making process. (ADR stands for Architecture Decision Record)
 
-For a full write up see [Michael Nygard's blog post on the topic](https://web.archive.org/web/20190430063238/http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+For a full write up see [Michael Nygard's blog post on ADRs](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).


### PR DESCRIPTION
The "dual URL" in the link prevented it working and the web.archive.org one does not seem to work at all anyway.

Also changed "this topic" in the wording to "ADRs".