### PR TITLE
Update Senior 1 to Senior Software Engineer

### DIFF
--- a/roles/README.md
+++ b/roles/README.md
@@ -12,7 +12,7 @@ looking for more responsibilities.
  - [Academy Software Engineer](academy_software_engineer.md)
  - [Software Engineer 1](software_engineer_1.md)
  - Software Engineer 2
- - [Senior Software Engineer 1](senior_software_engineer_1.md) – also looking for strong AWS experience for a [full stack role in Bristol](senior_software_engineer_1_with_aws.md)
+ - [Senior Software Engineer](senior_software_engineer.md) – also looking for strong AWS experience for a [full stack role in Bristol](senior_software_engineer_with_aws.md)
  - [Senior Software Engineer 2](senior_software_engineer_2.md) – often advertised as Lead Software Engineer
 
 You may have also seen that we have people in Tech Lead and Tech Architect roles. These are hats worn by appropriate Senior 1 and 2s.

--- a/roles/senior_software_engineer.md
+++ b/roles/senior_software_engineer.md
@@ -1,34 +1,33 @@
-# Senior Software Engineer with strong AWS experience
+# Senior Software Engineer
 
-Bristol, UK.
+Manchester & London, UK.
 
 Please apply for this role at [www.madetech.com/careers](https://www.madetech.com/careers).
 
-We are looking for Senior Engineers with a particular penchant and love for cloud, automation, slick tooling, and empowering software delivery by coaching teams in true DevOps fashion. While we are looking for those with significant experience working with AWS this role remains a full stack and polyglot role as with all of our Software Engineering roles.
-
-Our Senior Engineers combine technical excellence, drive to deliver, and coaching, to achieve outcomes for our customers and their users, and to establish strong engineering cultures within our customers organisations. They find themselves working on a variety of different problems from monoliths to microservices, upskilling colleagues and customers, always finding themselves learning from others, while constantly striving to be nice humans :)
+Our Senior Software Engineers are senior contributors to digital, data and technology outcomes that improve society. They do this by delivering and architecting software, and coaching others to do so in public sector organisations.
 
 ## What does the job entail?
 
 We primarily write and deliver custom software for the public sector. We work across central and local government, as well as in health, and our past lies in the technology startup world. Technical excellence for us isn’t about delivering to feature lists. We place a strong emphasis on outcome-based delivery; ensuring our customer’s goals are understood and achieved with the technology we deploy.
 
+Senior Software Engineers find themselves working on a variety of different problems from monoliths to microservices, upskilling colleagues and customers, always finding themselves learning from others, while constantly striving to be nice humans :)
+
+Our teams have used Ruby with Rails and Sinatra, ES6 with React and Angular 2, C# with .NET Core. We don’t limit ourselves as a company and we expect all our Engineers to be keen on learning new technologies. Automation is important to our teams, so we make sure there is a CD pipeline set up to build, test, and release many times per day.
+
 High performing software delivery teams need to be empowered to iteratively and rapidly deliver changes all the way through to production. To do this we combine our extensive cloud automation knowledge with DevOps culture.
 
 We've been using AWS from the start and as Advanced Partners are go to experts within the public sector. We use a range of IaaS, PaaS and FaaS depending on the needs of our users, in this case software teams, such as EC2, Lambda, ECS, Kubernetes, Heroku, CloudFoundry, Azure App Services, and more. We use VPC and PrivateLink for connecting to on-premise, legacy systems. We also use API Gateway, S3, CloudFront, SQS, SNS, SES, RDS, and many other services provided by AWS.
 
-We ensure we document our architecture and infrastructure as code, using technologies such as Terraform and OpenAPI. Containerisation is a big part of empowering our teams to develop, deploy and scale their applications, but so too is using AWS Lambda and avoiding the complexity of stateful services altogther. Right tool for the job.
+We ensure we document our architecture and infrastructure as code, using technologies such as Terraform and OpenAPI. Containerisation is a big part of empowering our teams to develop, deploy and scale their applications, but so too is using AWS Lambda and avoiding the complexity of stateful services altogether. Right tool for the job.
 
 For us, DevOps is about culture rather than roles and titles. Even though this role is for someone with strong DevOps experience, the biggest impact you will have is coaching and helping teams use the platforms you build. You won't be building infrastructure in isolation or charged with deploying other peoples work into production. You'll empower teams with the mantra: you build it, you run it!
 
-Our teams have used Ruby with Rails and Sinatra, ES6 with React and Angular 2, C# with .NET Core. We don’t limit ourselves as a company and we expect all our Engineers to be keen on learning new technologies. Automation is important to our teams, so we make sure there is a CD pipeline set up to build, test, and release many times per day.
-
-We grow a team of polyglot programmers, which you might already consider yourself to be, who are versed in a mix of paradigms such as object-oriented, functional, declarative, event-based and aspect-oriented. To create this environment our Senior Engineers need to embrace sharing their knowledge and skills with others, and they need to keep an open mind – we’d love to hear some examples of mentoring, coaching and growing team members. Maybe you will have written some blog posts about your discipline, or perhaps even delivered a talk or two.
+We grow a team of polyglot programmers, which you might already consider yourself to be, who are versed in a mix of paradigms such as object-oriented, functional, declarative, event-based and aspect-oriented. To create this environment our Senior Software Engineers need to embrace sharing their knowledge and skills with others, and they need to keep an open mind – we’d love to hear some examples of mentoring, coaching and growing team members. Maybe you will have written some blog posts about your discipline, or perhaps even delivered a talk or two.
 
 ## What experience are we looking for?
 
 While we will look for you to have experience in these things, if you don’t have one of these don’t let that stop you applying.
 
-- Deep working knowledge of developing and maintaining AWS infrastructure
 - Written code with tests
 - Delivered in an agile environment
 - Worked with more than one programming language
@@ -44,8 +43,6 @@ While we will look for you to have experience in these things, if you don’t ha
 
 Don’t forget to mention any of the experience listed below. While it’s optional, it’s all highly desired!
 
-- AWS DevOps Professional Qualification
-- Experience using a wide-breadth of AWS services including EC2, Lambda, ECS, EKS, API Gateway, S3, CloudFront, SQS, SNS, SES, RDS, etc.
 - Consultancy
 - Working directly with customers and users
 - Working within multidisciplinary teams with product, design, and technology working within the same cycles
@@ -91,7 +88,8 @@ Compensating you fairly:
 
 ## Salary
 
-This role has a salary of £45-70k depending on experience.
+- Manchester: £45,900-£63,000
+- London: £51,000-£70,000
 
 ## Applying
 

--- a/roles/senior_software_engineer_with_aws.md
+++ b/roles/senior_software_engineer_with_aws.md
@@ -1,31 +1,34 @@
-# Senior Software Engineer 1
+# Senior Software Engineer with strong AWS experience
 
-Manchester & London, UK.
+Bristol, UK.
 
-Please apply for this role at [www.madetech.com/careers](https://www.madetech.com/careers). 
+Please apply for this role at [www.madetech.com/careers](https://www.madetech.com/careers).
 
-Our Senior Engineers combine technical excellence, drive to deliver, and coaching, to achieve outcomes for our customers and their users, and to establish strong engineering cultures within our customers organisations. They find themselves working on a variety of different problems from monoliths to microservices, upskilling colleagues and customers, always finding themselves learning from others, while constantly striving to be nice humans :)
+We are looking for Senior Software Engineers with a particular penchant and love for cloud, automation, slick tooling, and empowering software delivery by coaching teams in true DevOps fashion. While we are looking for those with significant experience working with AWS this role remains a full stack and polyglot role as with all of our Software Engineering roles.
+
+Our Senior Software Engineers combine technical excellence, drive to deliver, and coaching, to achieve outcomes for our customers and their users, and to establish strong engineering cultures within our customers organisations. They find themselves working on a variety of different problems from monoliths to microservices, upskilling colleagues and customers, always finding themselves learning from others, while constantly striving to be nice humans :)
 
 ## What does the job entail?
 
 We primarily write and deliver custom software for the public sector. We work across central and local government, as well as in health, and our past lies in the technology startup world. Technical excellence for us isn’t about delivering to feature lists. We place a strong emphasis on outcome-based delivery; ensuring our customer’s goals are understood and achieved with the technology we deploy.
 
-Our teams have used Ruby with Rails and Sinatra, ES6 with React and Angular 2, C# with .NET Core. We don’t limit ourselves as a company and we expect all our Engineers to be keen on learning new technologies. Automation is important to our teams, so we make sure there is a CD pipeline set up to build, test, and release many times per day.
-
 High performing software delivery teams need to be empowered to iteratively and rapidly deliver changes all the way through to production. To do this we combine our extensive cloud automation knowledge with DevOps culture.
 
 We've been using AWS from the start and as Advanced Partners are go to experts within the public sector. We use a range of IaaS, PaaS and FaaS depending on the needs of our users, in this case software teams, such as EC2, Lambda, ECS, Kubernetes, Heroku, CloudFoundry, Azure App Services, and more. We use VPC and PrivateLink for connecting to on-premise, legacy systems. We also use API Gateway, S3, CloudFront, SQS, SNS, SES, RDS, and many other services provided by AWS.
 
-We ensure we document our architecture and infrastructure as code, using technologies such as Terraform and OpenAPI. Containerisation is a big part of empowering our teams to develop, deploy and scale their applications, but so too is using AWS Lambda and avoiding the complexity of stateful services altogether. Right tool for the job.
+We ensure we document our architecture and infrastructure as code, using technologies such as Terraform and OpenAPI. Containerisation is a big part of empowering our teams to develop, deploy and scale their applications, but so too is using AWS Lambda and avoiding the complexity of stateful services altogther. Right tool for the job.
 
 For us, DevOps is about culture rather than roles and titles. Even though this role is for someone with strong DevOps experience, the biggest impact you will have is coaching and helping teams use the platforms you build. You won't be building infrastructure in isolation or charged with deploying other peoples work into production. You'll empower teams with the mantra: you build it, you run it!
 
-We grow a team of polyglot programmers, which you might already consider yourself to be, who are versed in a mix of paradigms such as object-oriented, functional, declarative, event-based and aspect-oriented. To create this environment our Senior Engineers need to embrace sharing their knowledge and skills with others, and they need to keep an open mind – we’d love to hear some examples of mentoring, coaching and growing team members. Maybe you will have written some blog posts about your discipline, or perhaps even delivered a talk or two.
+Our teams have used Ruby with Rails and Sinatra, ES6 with React and Angular 2, C# with .NET Core. We don’t limit ourselves as a company and we expect all our Engineers to be keen on learning new technologies. Automation is important to our teams, so we make sure there is a CD pipeline set up to build, test, and release many times per day.
+
+We grow a team of polyglot programmers, which you might already consider yourself to be, who are versed in a mix of paradigms such as object-oriented, functional, declarative, event-based and aspect-oriented. To create this environment our Senior Software Engineers need to embrace sharing their knowledge and skills with others, and they need to keep an open mind – we’d love to hear some examples of mentoring, coaching and growing team members. Maybe you will have written some blog posts about your discipline, or perhaps even delivered a talk or two.
 
 ## What experience are we looking for?
 
 While we will look for you to have experience in these things, if you don’t have one of these don’t let that stop you applying.
 
+- Deep working knowledge of developing and maintaining AWS infrastructure
 - Written code with tests
 - Delivered in an agile environment
 - Worked with more than one programming language
@@ -41,6 +44,8 @@ While we will look for you to have experience in these things, if you don’t ha
 
 Don’t forget to mention any of the experience listed below. While it’s optional, it’s all highly desired!
 
+- AWS DevOps Professional Qualification
+- Experience using a wide-breadth of AWS services including EC2, Lambda, ECS, EKS, API Gateway, S3, CloudFront, SQS, SNS, SES, RDS, etc.
 - Consultancy
 - Working directly with customers and users
 - Working within multidisciplinary teams with product, design, and technology working within the same cycles
@@ -86,7 +91,7 @@ Compensating you fairly:
 
 ## Salary
 
-This role has a salary of £50-75k depending on experience.
+- Bristol: £45,900-£63,000
 
 ## Applying
 


### PR DESCRIPTION
# What

- Change job title
- Change advertised salaries*
- Updated description slightly

*To be clear this does not impact existing salaries and as ever we remain committed to transparency of salaries in job descriptions and also internally so that everyone knows that anyone with a role is paid within the internal salary range.

# Why

As part of move from Senior 1 + 2 to Senior and Lead we are updating job descriptions and salaries. 