### PR TITLE
Improved parental leave

### DIFF
--- a/guides/welfare/parental_leave.md
+++ b/guides/welfare/parental_leave.md
@@ -1,38 +1,39 @@
 # Maternity, Paternity & Shared Parental Leave
 
 Whether because you or your partner is having a baby, if you're adopting a child or having a baby through a surrogacy arrangement, Made Tech encourages you to take leave so that you can welcome the new child (or children!) into your family.
+Our paid Parental leave is the same for all!
 
 ## Maternity Leave
 
-We provide 2 weeks Maternity Leave at full pay followed by statutory pay for a further 37 weeks. You can take up to a total of 52 weeks.
+We provide 12 weeks Maternity Leave at full pay followed by statutory pay for a further 26 weeks. You can take up to a total of 52 weeks.
 
 The breakdown of pay is as follows:
 
-- 2 weeks at 100% pay
-- 4 weeks at 90% pay
-- 33 weeks at £140.98 or 90% pay which ever is lower
+- 12 weeks at 100% pay
+- 6 weeks at 90% pay
+- 33 weeks at £151.20 or 90% pay which ever is lower
 
 There are detailed government guidelines here: [www.gov.uk/employers-maternity-pay-leave](https://www.gov.uk/employers-maternity-pay-leave).
 
 ## Paternity Leave
 
-We provide 2 weeks Paternity Leave at full pay and the option of shared parental leave. The paternity leave must end within 56 days of the birth.
+We provide 12 weeks Paternity Leave at full pay and the option of shared parental leave. The paternity leave must end within 56 days of the birth.
 
 The breakdown of pay is as follows:
 
-- 2 weeks at 100% pay
+- 12 weeks at 100% pay
 
 Government guidelines available here: [www.gov.uk/paternity-pay-leave](https://www.gov.uk/paternity-pay-leave).
 
 ## Shared Parental Leave
 
-We provide two weeks Shared Parental Leave at full pay and up to 37 weeks at statutory pay.
+We provide 12 weeks Shared Parental Leave at full pay and up to 39 weeks at statutory pay.
 
 The breakdown of pay is as follows if you qualify for SPL:
 
-- 2 weeks at 100% pay
-- 4 weeks at 90% pay
-- 33 weeks at £140.98 or 90% pay which ever is lower
+- 12 weeks at 100% pay
+- 6 weeks at 90% pay
+- 33 weeks at £151.20 or 90% pay which ever is lower
 
 The rules around SPL are fairly complex, government guidelines are available here: [https://www.gov.uk/shared-parental-leave-and-pay](https://www.gov.uk/shared-parental-leave-and-pay).
 


### PR DESCRIPTION
Increasing our parental paid leave from 2 to 12 weeks! This is for maternity, paternity, adoption etc. Also updated the SMP and SPP amounts as they have increased since this page was created.