### PR TITLE
Add Principal Technologist role

### DIFF
--- a/roles/README.md
+++ b/roles/README.md
@@ -14,6 +14,7 @@ looking for more responsibilities.
  - Software Engineer 2
  - [Senior Software Engineer](senior_software_engineer.md) – also looking for strong AWS experience for a [full stack role in Bristol](senior_software_engineer_with_aws.md)
  - [Lead Software Engineer](lead_software_engineer.md)
+ - [Principal Technologist](principal_technologist.md)
 
 You may have also seen that we have people in Tech Lead and Tech Architect roles. These are hats worn by appropriate Senior 1 and 2s.
 

--- a/roles/principal_technologist.md
+++ b/roles/principal_technologist.md
@@ -1,0 +1,85 @@
+# Principal Technologist
+
+Bristol, Manchester & London, UK.
+
+Please apply for this role at [www.madetech.com/careers](https://www.madetech.com/careers).
+
+Our Principal Technologists enable public sector organisations to better use technology in order to improve society. They do this by building and managing strategic relationships, leading accounts, finding new opportunities and advising as a senior technology leader.
+
+## What does the job entail?
+
+At Made Tech we want to positively impact the future of the country by using technology to improve society. We help public sector organisations deliver quality software to help citizens get more from public services. To do this we work alongside brilliant public servants to modernise technology and accelerate digital delivery.
+
+As a Principal Technologist you will work closely with our customers senior leadership to help inform their strategy and to ensure our teams are delivering to a high quality and are aligned to our customers technology vision. As part of an account team, alongside Delivery and Client Leads, you will help shape account plans and be responsible for delivering against them.
+
+Working with Made Tech's regional and group leadership you will ensure our work with customers is aligned to our growth goals and you will play a pivotal role in identifying new opportunities and winning work. Running bid teams, supporting wider sales team and developing new business is critical to this role.
+
+You will coach and support Lead Software Engineers to steer their team's towards success. You will also be responsible for hiring and line managing Lead Software Engineers.
+
+While this is not a hands-on technical role, the importance of credibility in internet-era approaches to digital and technology in the public sector cannot be understated. You will be expected to maintain a broad technical knowledge of modern software development practices, be able to shape technology strategy and roadmaps, and hold others to account for technical quality.
+
+As a technology leader within Made Tech you will be expected to maintain and grow your professional network. You will be expected to contribute to thought leadership, content and events and should have a proven track record of doing so.
+
+## What experience are we looking for?
+
+While we will look for you to have experience in these things, if you don’t have one of these don’t let that stop you applying.
+
+- Working directly with customers and users
+- Working within a technology consultancy
+- Strong understanding of agile ways of working
+- Strong understanding of software engineering practice
+- Strong understanding of cloud technologies
+- Evidence of self-development – we value keen learners
+- Drive to deliver outcomes for users
+- Desire to mentor others
+- Empathy and people skills
+
+## Optional experience
+
+Don’t forget to mention any of the experience listed below. While it’s optional, it’s all highly desired!
+
+- Working within an account or programme leadership team
+- Working within bid teams to win contracts exceeding value of £1m
+- Working with multidisciplinary digital and technology teams
+- Working within the public sector
+- Experience in hiring, forming and running software teams
+- Experience in legacy application modernisation
+- Maintain a deep working knowledge of technology and programming languages
+
+## What we will provide you
+
+Balancing life and work:
+
+* ✈️ [Flexible Holiday](../benefits/flexible_holiday.md) – We trust you to take as much holiday as you need
+* 🕰️ [Flexible Working Hours](../benefits/working_hours.md) – We are flexible with what hours you work
+* 🗓️ [Flexible Working Days](../benefits/flexible_working.md) – We are flexible to the amount of days you work in a week
+* 👶 [Flexible Parental Leave](../guides/welfare/parental_leave.md) – We provide flexible parental leave options
+* 👩‍💻 [Remote Working](../benefits/remote_working.md) – We offer part-time remote working for all our staff
+* 🤗 [Paid counselling](../guides/welfare/employee_assistance.md) – We offer paid counselling as well as financial and legal advice
+* 🏖️ [Paid anniversary break](../benefits/paid_anniversary_break.md) – We celebrate your 3 and 5 year anniversary with us by buying your family a holiday
+
+Making work as fabulous as possible:
+
+* 💻 [Work Ready](../benefits/work_ready.md) – We'll buy you a Macbook, ergonomic equipment, books, conferences, training, and more
+* 💡 [Learn Tech](../guides/learning/README.md) – We spend every Friday afternoon learning rather than working
+* 🍽️ [Friday Lunches](../benefits/friday_lunch.md) – We randomly match up 8 colleagues every Friday and pay for lunch
+* 🍻 [Friday Drinks](../benefits/friday_drinks.md) – We pay for social drinks on a Friday
+
+Compensating you fairly:
+
+* 💷 [Transparent Salary Bands](../roles/README.md) – We publish salary bands so you know you're being fairly compensated
+* 👌 [Annual Salary Reviews](../guides/compensation/salary_reviews.md) – We review your salary on an annual basis
+* ⛷️ [Pension Scheme](../benefits/pension_scheme.md) – We provide a pension scheme so you can save for your future and we'll contribute to it
+* 🚄 [Season Ticket Loan](../benefits/season_ticket_loan.md) – We provide loans to help you pay for your travel
+* 🚲 [Cycle To Work Scheme](../benefits/cycle_to_work_scheme.md) – We offer the cycle to work scheme to help pay for your bicycle
+* 🚕 [Expenses Paid](../guides/compensation/expenses.md) – Taxi to a meeting? Want to take a customer to lunch? Expenses are no hassle!
+
+## Salary
+
+- Bristol: £81,900+
+- Manchester: £81,900+
+- London: £91,000+
+
+## Applying
+
+Please apply for this role at [www.madetech.com/careers](https://www.madetech.com/careers). If you don't quite fit the role, the role doesn't quite fit you, or you have questions please email us at [careers@madetech.com](mailto:careers@madetech.com) where we will be happy to help.


### PR DESCRIPTION
## What

- Add job description
- Add link to job description from roles README

## Why

This role enables us to provide bandwidth for senior technical leadership within accounts, focussing time on strategic growth and ensuring quality as a scale.