### PR TITLE
Update README to reference Senior and Lead

### DIFF
--- a/roles/README.md
+++ b/roles/README.md
@@ -15,7 +15,7 @@ looking for more responsibilities.
  - [Senior Software Engineer](senior_software_engineer.md) – also looking for strong AWS experience for a [full stack role in Bristol](senior_software_engineer_with_aws.md)
  - [Lead Software Engineer](lead_software_engineer.md)
 
-You may have also seen that we have people in Tech Lead and Tech Architect roles. These are hats worn by appropriate Senior 1 and 2s.
+You may have also seen that we have people in Tech Lead and Tech Architect roles. These are hats worn by Senior and Lead Engineers.
 
 ### Delivery
 


### PR DESCRIPTION
## What

Replace references to S1 and S2 with Senior and Lead.

## Why

S1 and S2 are old roles that have been deprecated.