### PR TITLE
Add a page for software engineer 2

### DIFF
--- a/roles/README.md
+++ b/roles/README.md
@@ -11,7 +11,7 @@ looking for more responsibilities.
 
  - [Academy Software Engineer](academy_software_engineer.md)
  - [Software Engineer 1](software_engineer_1.md)
- - Software Engineer 2
+ - [Software Engineer 2](software_engineer_2.md)
  - [Senior Software Engineer](senior_software_engineer.md) – also looking for strong AWS experience for a [full stack role in Bristol](senior_software_engineer_with_aws.md)
  - [Lead Software Engineer](lead_software_engineer.md)
  - [Principal Technologist](principal_technologist.md)

--- a/roles/software_engineer_1.md
+++ b/roles/software_engineer_1.md
@@ -46,7 +46,7 @@ Compensating you fairly:
 
 The salary for this role is location dependant:
 
-*London:* £30000 to £40000
+*London:* £30000 to £39000
 *Manchester:* £27000 to £36000
 *Bristol:* £27000 to £36000
 

--- a/roles/software_engineer_1.md
+++ b/roles/software_engineer_1.md
@@ -44,7 +44,11 @@ Compensating you fairly:
 
 ## Salary
 
-This role has a salary of £30-40k.
+The salary for this role is location dependant:
+
+*London:* £30000 to £40000
+*Manchester:* £27000 to £36000
+*Bristol:* £27000 to £36000
 
 ## Applying
 

--- a/roles/software_engineer_2.md
+++ b/roles/software_engineer_2.md
@@ -1,4 +1,4 @@
-# Software Engineer 1
+# Software Engineer 2
 
 Bristol, Manchester & London, UK.
 
@@ -12,7 +12,7 @@ Our teams have used Ruby with Rails and Sinatra, ES6 with React and Angular 2, C
 
 ## What experience are we looking for?
 
-All of our Software Engineers are trained first as an [Academy Software Engineer](academy_software_engineer.md) within our 12 week Academy programme. We don't currently hire people into this role without them first going through our Academy.
+All of our Software Engineers are trained first as an [Academy Software Engineer](academy_software_engineer.md) within our 12 week Academy programme. We don't currently hire people into this role without them first going through our Academy. This role is typically the next step in progression for Software Engineers, and reflects the greater range of skills learned and reponsibilities taken on as an Engineer progresses their career.
 
 ## What we will provide you
 
@@ -44,7 +44,7 @@ Compensating you fairly:
 
 ## Salary
 
-This role has a salary of £30-40k.
+This role has a salary of £40-50k.
 
 ## Applying
 

--- a/roles/software_engineer_2.md
+++ b/roles/software_engineer_2.md
@@ -44,7 +44,11 @@ Compensating you fairly:
 
 ## Salary
 
-This role has a salary of £40-50k.
+The salary for this role is location dependant:
+
+*London:* £41000 to £50000
+*Manchester:* £36900 to £45000
+*Bristol:* £36900 to £45000
 
 ## Applying
 

--- a/roles/software_engineer_2.md
+++ b/roles/software_engineer_2.md
@@ -46,7 +46,7 @@ Compensating you fairly:
 
 The salary for this role is location dependant:
 
-*London:* £41000 to £50000
+*London:* £40000 to £50000
 *Manchester:* £36900 to £45000
 *Bristol:* £36900 to £45000
 


### PR DESCRIPTION
The page is more or less a copy of Software Engineer 1 with a few tweaks.

Kept the same wording around hiring into these roles with minor tweaks to both to cover Academy -> E1 -> E2 typical progression.