### PR TITLE
Add SFIA expectations for technology roles

### DIFF
--- a/roles/README.md
+++ b/roles/README.md
@@ -9,12 +9,12 @@ looking for more responsibilities.
 
 ### Technology
 
- - [Academy Software Engineer](academy_software_engineer.md)
- - [Software Engineer 1](software_engineer_1.md)
- - [Software Engineer 2](software_engineer_2.md)
- - [Senior Software Engineer](senior_software_engineer.md)
- - [Lead Software Engineer](lead_software_engineer.md)
- - [Principal Technologist](principal_technologist.md)
+ - [Academy Software Engineer](academy_software_engineer.md) ([SFIA Level 1](sfia/academy_software_engineer.md))
+ - [Software Engineer 1](software_engineer_1.md) ([SFIA Level 2](sfia/software_engineer_1.md))
+ - [Software Engineer 2](software_engineer_2.md) ([SFIA Level 3](sfia/software_engineer_2.md))
+ - [Senior Software Engineer](senior_software_engineer.md) ([SFIA Level 4](sfia/senior_software_engineer.md))
+ - [Lead Software Engineer](lead_software_engineer.md) ([SFIA Level 5](sfia/lead_software_engineer.md))
+ - [Principal Technologist](principal_technologist.md) ([SFIA Level 6](sfia/principal_technologist.md))
 
 You may have also seen that we have people in Tech Lead and Tech Architect roles. These are hats worn by Senior and Lead Engineers.
 

--- a/roles/sfia/academy_software_engineer.md
+++ b/roles/sfia/academy_software_engineer.md
@@ -1,0 +1,52 @@
+# SFIA Role Guidance: Academy Software Engineer
+
+[SFIA Level 1: Follow](https://sfia-online.org/en/sfia-7/responsibilities/level-1)
+
+[next &raquo;](software_engineer_1.md)
+
+## Summary of role
+
+Attending Made Tech Academy to learn about software engineering in the public sector.
+
+## Required competency for role
+
+### Autonomy
+
+Works with other engineers above their level to be effective, seeking help rather than staying blocked and takes responsibility for requesting and addressing feedback on independent contributions.
+
+### Influence
+
+Shares opinions on approach with team and plays an active part in workshops and group activities.
+
+### Complexity
+
+Combines existing knowledge, additional research and direction from colleagues to complete tasks.
+
+### Knowledge
+
+Demonstrates ability to self-learn new knowledge, skills and behaviours.
+
+### Business Skills
+
+Has sufficient communication skills for effective dialogue with others.
+
+## Examples of behaviours and responsibilities
+
+Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
+
+- Learning the basics of how technology can be delivered with a Made Tech spin
+- Needs to pair with other Engineers above their level to be effective, but is likely to be mentor-mentee relationship
+- Seeks feedback and guidance on contributions
+- For contributions delivered independently; there is typically a lot of constructive feedback and guidance illuminates new knowledge and skills
+- Influencing others around them by sharing opinions on approach
+- Able to talk through thought process in pairing situations
+- Involved in mob sessions
+- Involved and engaged in retrospectives
+- More often than not needs to seek advice to raise issues or provide feedback to others
+- Applies what they have been taught in Academy by following rules, often without full consideration of the tradeoffs made
+- Needs to seeks advice to understand what is possible, and needs assistance to adapt to team delivery team specific needs
+- Is able to reason and strategise about tiny slices of a whole problem, and require assistance to consider wider impact of work
+- Is learning new knowledge, skills and behaviours
+- Needs regular advice and guidance
+- Is constantly re-defining internalised opinions based on new experiences and information
+- Can apply known concepts in new programming languages

--- a/roles/sfia/lead_software_engineer.md
+++ b/roles/sfia/lead_software_engineer.md
@@ -1,0 +1,65 @@
+# SFIA Role Guidance: Lead Software Engineer
+
+[SFIA Level 5: Ensure, Advise](https://sfia-online.org/en/sfia-7/responsibilities/level-5)
+
+[&laquo; previous](senior_software_engineer.md) | [next &raquo;](principal_technologist.md)
+
+## Summary of role
+
+Leads teams to deliver digital, data and technology outcomes that improve society. They do this by establishing and leading teams to deliver software in public sector organisations.
+
+## Required competency for role
+
+### Autonomy
+
+Accountable for workstream to customers, partners, account team, delivery assurance team and other stakeholders from a technical and delivery perspective.
+
+### Influence
+
+Drives workstream team towards technical excellence by influencing team, customers and partners.
+
+### Complexity
+
+Manages complex technical change of a workstream within a wider programme of work in multi-organisation stakeholder environments.
+
+### Knowledge
+
+Develops a deep understanding of digital and technology landscape in UK public sector.
+
+### Business Skills
+
+Demonstrates leadership. Communicates effectively, both formally and informally.
+
+## Examples of behaviours and responsibilities
+
+Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
+
+- Represents or delegates responsibility for representing workstream to customers, partners, account team, delivery assurance team and other stakeholders from a technical and sometimes delivery perspective
+- Coaches Senior Engineers within the workstream team and/or customer staff, providing continuous feedback to individuals and their line managers, and supporting line managers to find career progression opportunities
+- Able to lead bootup and delivery of a product workstream where outcomes are known, and the product is complicated rather than complex
+- Able to work as part of a leadership team (with delivery and product support) in a bootup and delivery of a product workstream where outcomes are unknown, and the product is complex
+- Able to work as part of a workstream team (with account and business support) in a bootup of a new account
+- Able to contribute within the account team in non-strategic accounts
+- Able to lead, advise and support up to two workstreams and ultimately be responsible for delivery of outcomes across their workstreams
+- Able to synthesise outcomes with senior stakeholders by facilitating inception and discovery work
+- Proactively identifies reputational and commercial risks and takes responsibility for mitigations and corrective actions
+- Ensures all technical staff in their workstream are operating at a good performance level at minimum, identifying performance issues and supporting correct action where necessary
+- Ensures their workstream team is operating in line with technical and delivery principles, and working towards technical excellence. Reports to the delivery assurance and account team
+- Builds relationships with senior customer stakeholders, maintains them and leverages those relationships in their work to influence, challenge and support technical practices and strategy
+- Works with customers, partners, account and workstream team to ensure workstream aligned with technical practices and strategy of customer organisation
+- Regularly influences and supports improvement of technical practices within a customer’s organisation at a community of practice or organisational level
+- Turns technical and delivery obstacles into opportunities for improvement and betterment of practices, and can lead a team to turn these opportunities into positive organisational impacts
+- Influences direction and day-to-day running of the account
+- Has overall technical authority within their workstreams
+- Influences organisation-wide approach to technology as part of the technology leadership team
+- Able to build relationships with senior customer and partner stakeholders, both technical and otherwise
+- Works with customers to define outcomes, deadlines and budgets
+- Has significant influence over the scheduling of technical staff to workstreams
+- Likely is the most senior day-to-day representative of Made Tech within the account
+- Ensures users’ needs are met consistently through each work stage
+- Influences the technology industry by engaging at public events
+- Able to architect and coordinate wide scale changes across multiple applications and platforms
+- Can design migration strategies in legacy environments and coordinate others to deliver
+- Can navigate complex stakeholder and organisational environments
+- Able to support and manage multiple workstreams, while delivering within one or more of those workstreams
+- Able to coordinate and manage supplier, partner and customer staff alongside Made Tech

--- a/roles/sfia/principal_technologist.md
+++ b/roles/sfia/principal_technologist.md
@@ -1,0 +1,51 @@
+# SFIA Role Guidance: Principal Technologist
+
+[SFIA 6: Initiate, Influence](https://sfia-online.org/en/sfia-7/responsibilities/level-6)
+
+[&laquo; previous](lead_software_engineer.md)
+
+## Summary of role
+
+Enables public sector organisations to better use technology in order to improve society. They do this by building and managing strategic relationships, leading accounts, finding new opportunities and advising as a senior technology leader.
+
+## Required competency for role
+
+### Autonomy
+
+Accountable for the technology strategy within an account, technical direction and quality of workstreams, and driving new opportunities through technical advice.
+
+### Influence
+
+Builds and maintains influential relationships with senior leadership, particularly technology leaders, of customer and partner organisations as well as wider industry.
+
+### Complexity
+
+Has a broad business understanding, a deep understanding of digital and technology and performs highly complex work activities covering technical, financial and quality aspects.
+
+### Knowledge
+
+Develops a deep understanding of digital and technology landscape in UK public sector, including customers, suppliers, partners and competitors.
+
+### Business Skills
+
+Demonstrates clear leadership. Communicates effectively at all levels to both technical and non-technical audiences.
+
+## Examples of behaviours and responsibilities
+
+Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
+
+- Works with workstreams to ensure technical direction is aligned across our work and with customers organisation
+- Builds and maintains relationships with senior customer and partner leadership, particularly senior technology leadership
+- Responsible for Made Tech’s reputation within an account and ensuring our teams are perceived positively by customers, partners and suppliers
+- Coaches and supports Lead Software Engineers to deliver their workstream outcomes successfully
+- May perform role across one or more accounts
+- Operates as senior hiring manager of technology staff within the region
+- Works closely with regional leadership to ensure the account plan is aligned with regional growth goals
+- Identifies and generates new opportunities within an account and region through networking, advice and thought leadership
+- Able to lead, create and present proposals for opportunities as part of the bid process
+- Defines account plan as part of an account team and leads the team to deliver against it
+- Has authority over accounts technology staff, though as a servant leader seeks to facilitate rather than make decisions in isolation
+- Works with regional leadership to define regional hiring requirements
+- Works with group technology leader (CTO) to define both regional and group outcomes for technology, and coordinates regional technologists to deliver these outcomes
+- Nurtures and grows their own professional network and can use this to support and win new business
+- Is known as a technology leader within their region

--- a/roles/sfia/senior_software_engineer.md
+++ b/roles/sfia/senior_software_engineer.md
@@ -1,0 +1,65 @@
+# SFIA Role Guidance: Senior Software Engineer
+
+[SFIA Level 4: Enable](https://sfia-online.org/en/sfia-7/responsibilities/level-4)
+
+[&laquo; previous](software_engineer_2.md) | [next &raquo;](lead_software_engineer.md)
+
+## Summary of role
+
+Senior contributor to digital, data and technology outcomes that improve society. They do this by delivering and architecting software, and coaching others to do so in public sector organisations.
+
+## Required competency for role
+
+### Autonomy
+
+Collaboratively leads workstream team to deliver complex change and supports development of others to do the same.
+
+### Influence
+
+Facilitates the design of architecture, technical decision making and agreeing ways of working.
+
+### Complexity
+
+Manages complex technical change across multiple systems and legacy technology.
+
+### Knowledge
+
+Expert across multiple languages, frameworks and technologies.
+
+### Business Skills
+
+Communicates fluently, orally and in writing, and can present complex information to both technical and non-technical audiences.
+
+## Examples of behaviours and responsibilities
+
+Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
+
+- Ships complex features collaboratively and independently as appropriate and is recognised as a key player of the team
+- Pairs with and coaches junior members of the team and/or customer staff, supporting line managers to find career progression opportunities within the workstream
+- Able to lead a bootup and delivery of a product workstream where outcomes are known, and the product is complicated rather than complex, with support and coaching from a Lead
+- Continues to seek consensus with approaches, and feedback on work as it is iteratively delivered
+- Confidently facilitates retrospectives and other team ceremonies regularly, and delivers Learn Tech showcases
+- Has strong awareness of how Made Tech is perceived by customers and partners, as well as how colleagues and themself is perceived by other colleagues, will provide direct performance data and feedback in order to rectify the situation
+- Plays an active part in evolving Made Tech's approach to modern technology delivery
+- Identifies performance issues within the workstream team and works with individuals and line managers supporting correct action where necessary
+- Facilitates the design of architecture with customers, partners and workstream team through workshops and other collaborative formats
+- Shapes backlog collaboratively, providing technical leadership within backlog planning and refinement sessions, as well as in three amigos
+- Influences ways of working and helps to facilitate alignment between customers, partners and workstream team
+- Influences Made Tech account leads in terms of how the account is organised and run.  
+- May have (or shares with customer) authority over approach to delivering workstream, though as a servant leader seeks to facilitate rather than make decisions in isolation
+- Likely leads or is a major contributor to meetups, communities of practice and working groups
+- Engages outside immediate worksteam as a trusted advisor to customers and partners
+- Engages to ensure that user needs are being met throughout
+- Able to architect and deliver complex features
+- Able to work across multiple applications to deliver system-wide features and changes to architecture
+- Able to navigate large customer organisations
+- Can deliver legacy migrations
+- Able to maintain a calm and collected approach to fixing issues in chaotic environments
+- Has deep knowledge of Made Tech both commercially and technically
+- Are endorsed by colleagues as expert in a number of skills
+- Seen by customer as an expert in their domain
+- Able to apply technical knowledge within complex environments
+- Has passed industry recognised training certifications at a professional level
+- Actively mentoring, training and coaching colleagues in areas of expertise
+- Can rapidly learn new technology
+- Spearheads introduction of new concepts into Made Tech

--- a/roles/sfia/software_engineer_1.md
+++ b/roles/sfia/software_engineer_1.md
@@ -1,0 +1,51 @@
+# SFIA Role Guidance: Software Engineer 1
+
+[SFIA Level 2: Assist](https://sfia-online.org/en/sfia-7/responsibilities/level-2)
+
+[&laquo; previous](academy_software_engineer.md) | [next &raquo;](software_engineer_2.md)
+
+## Summary of role
+
+Assists in the delivery of digital, data and technology outcomes that improve society. They do this by autonomously developing software features and contributing ideas to workstream direction.
+
+## Required competency for role
+
+### Autonomy
+
+Can autonomously deliver features ensuring the quality of their work by proactively seeking and addressing feedback.
+
+### Influence
+
+Can form own opinions on how to iteratively develop a feature, validates these opinions with workstream team and contributes in workshops with customers.
+
+### Complexity
+
+Balances user needs with technical complexity to deliver all aspects of a feature including UI, API, DB and business logic components.
+
+### Knowledge
+
+Able to acquire new knowledge in order to deliver features within estimated time.
+
+### Business Skills
+
+Has sufficient communication skills for effective dialogue with customers, suppliers and partners.
+
+## Examples of behaviours and responsibilities
+
+Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
+
+- With limited experience in modern technology consulting sector
+- Still learning how Made Tech delivers technology, and may need to pair on occasion to be effective
+- Is able to more often than not participate equally in a pair with others
+- For the majority of the time, is able to contribute independently without pairing
+- Seeks feedback and guidance where appropriate; typically receives some constructive feedback and occassionally guidance highlights gaps in knowledge and skills
+- Influencing immediate colleagues regularly by sharing opinions and ideas
+- Challenges other Made Tech colleagues ideas tactfully when in disagreement
+- Has been involved in workshops, retrospectives or other activities where ideas and opinions are shared between customers and Made Tech colleagues
+- Would typically gain the ability to provide ideas, opinions and advice on specific subset of a customer's domain
+- Beginning to understand tradeoffs and is learning to make adjustments to approach for the current context
+- Is able to reason about subsets of a domain, building up a good working knowledge of wider technological & user needs
+- Has a grounding in foundational knowledge, skills and behaviours
+- Able to mentor others in some skills
+- Navigates available workshops to learn skills necessary to be effective on Delivery Teams
+- Has a good working knowledge of the customer domain

--- a/roles/sfia/software_engineer_2.md
+++ b/roles/sfia/software_engineer_2.md
@@ -1,0 +1,63 @@
+# SFIA Role Guidance: Software Engineer 2
+
+[SFIA Level 3: Apply](https://sfia-online.org/en/sfia-7/responsibilities/level-3)
+
+[&laquo; previous](software_engineer_1.md) | [next &raquo;](senior_software_engineer.md)
+
+## Summary of role
+
+Contributor to digital, data and technology outcomes that improve society. They do this by architecting and delivering features.
+
+## Required competency for role
+
+### Autonomy
+
+Collaboratively leads planning of work, development of features and coordinating with stakeholders though continues to seek feedback and support on complex change.
+
+### Influence
+
+Influences approaches taken by workstream team to deliver features, contributes to quality assurance of teams work and ensures features meet project outcomes and user needs.
+
+### Complexity
+
+Manages complex technical change in a single system and will seek support when managing change across multiple systems.
+
+### Knowledge
+
+Proficient in multiple languages, frameworks and technologies.
+
+### Business Skills
+
+Demonstrates effective communication skills.
+
+## Examples of behaviours and responsibilities
+
+Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
+
+- Understands and is able to demonstrate Made Tech's approach to modern technology delivery
+- Is participating equally when pairing
+- Will autonomously pick up and deliver features that they can see a clear solution to and have delivered similarly in the past
+- Will proactively pick up complex features, but will seek guidance on approach before proceeding and will seek feedback via pull requests and pairing from senior members of the team
+- Will take initiative as to whether they can resolve issues themselves or need to loop in more senior member of the team
+- Is building an awareness of how Made Tech is perceived by customers and partners, as well as how they and their colleagues are perceived by other colleagues – is developing a sense when something isn't right and needs escalating
+- Influencing workstream at a feature level, helping to define features and approaches for delivering them
+- Influencing a wider range of colleagues through sharing opinions and ideas in forums outside of their immediate deliveries
+- Expected to also seek opportunities to share opinions and ideas to peers within customer and partner organisations
+- Provides guidance and support to more junior members of the team in helping them identify what work to pick up
+"Able to iteratively deliver features of reasonable complexity, in known contexts
+- Able to architect and deliver simple features in new contexts
+- Uses a range of techniques and best practices to build easy to maintain solutions
+- Has developed strong debugging skills, and can remediate issues both locally and in deployed environments
+- Able to work effectively in brownfield projects within days
+- Proficient in multiple languages, frameworks and technologies
+- Able to be proficient within many contexts due to varied and deepening knowledge of technologies
+- Able to mentor, train and coach others in their areas of knowledge
+- Are endorsed by colleagues as knowledgable in a number of skills
+- Working towards industry recognised training certifications
+- Shares knowledge with others through blog posts and talks
+- Demonstrates effective communication skills
+- Plans, schedules and monitors own work (and that of others where applicable) competently within limited deadlines and according to relevant legislation, standards and procedures
+- Contributes fully to the work of teams. Appreciates how own role relates to other roles and to the business of the employer or client
+- Demonstrates an analytical and systematic approach to issue resolution
+- Takes the initiative in identifying and negotiating appropriate personal development opportunities
+- Understands how own role impacts security and demonstrates routine security practice and knowledge required for own work


### PR DESCRIPTION
## What

- Add role summary and required competencies for all technology roles
- Add SFIA examples to all technology roles
- Add links to SFIA guidance from roles/README.md
- Include navigation between each SFIA level
- Include links to official SFIA guidance for each level

## Why

### Moving SFIA guidance to handbook

This change sees us move SFIA guidance out of documents and spreadsheets and into the handbook where it will be more accessible.

### Simplifying SFIA guidance

Since introducing SFIA we've received feedback that it isn't clear how to use SFIA guidance for roles and that each role has so many examples it is hard to know what good looks like for a particular role.

In order to make technology SFIA guidance clearer for each role, we've provided single sentence (in most cases) summaries of autonomy, influence, complexity, knowledge and business skills within our organisation and public sector industry context.

We've kept examples from existing SFIA guidance but have put these at the end of each summary and hopefully clearly convey that these are provided as illustrative examples only and should not be used as checklists.

## Future changes

The people team are in the process of putting guidance together for line managers and those seeking to develop their careers on how SFIA can be used for probation and performance reviews, pay rises and promotions.

## Reviewing these changes

You can review these changes by:

- Start from [roles/README.md](https://github.com/madetech/handbook/blob/sfia-for-tech-roles/roles/README.md)
- Click "SFIA" next to a technology role
- Use "< previous" and "next >" to navigate between SFIA levels