### PR TITLE
Add clarification around where to find password for welcome form

### DIFF
--- a/company/welcome_pack.md
+++ b/company/welcome_pack.md
@@ -23,7 +23,7 @@ Our on-boarding checklist is hosted on airtable. You will receive a link to your
 
 * [ ] Signed Contract
 * [ ] Tour of the office
-* [ ] Complete [welcome form](https://madetech.typeform.com/to/neqgrr)
+* [ ] Complete [welcome form](https://madetech.typeform.com/to/neqgrr) (the password for this form can be found in the `int-onboarding` 1password vault)
 * [ ] Introduction to company mission, business services, and EOS
 * [ ] Meet your buddy
 * [ ] Attend first career development 121 to introduce role expectations


### PR DESCRIPTION
There is currently no reference as to where to find the password for the welcome form in the handbook (currently mentions lastpass on the form itself).

Adding a note on where to find it in the handbook rather than on the form itself to make it easier to update should the location change in future.
