### PR TITLE
Add information about other options for paid counselling

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Balancing life and work:
 * 🗓️ [Flexible Working Days](benefits/flexible_working.md) – We are flexible to the amount of days you work in a week
 * 👶 [Flexible Parental Leave](guides/welfare/parental_leave.md) – We provide flexible parental leave options
 * 👩‍💻 [Remote Working](benefits/remote_working.md) – We offer part-time remote working for all our staff
-* 🤗 [Paid counselling](guides/welfare/employee_assistance.md) – We offer paid counselling as well as financial and legal advice
+* 🤗 [Paid counselling](guides/welfare/paid_counselling.md) – We offer paid counselling as well as financial and legal advice
 * 🏖️ [Paid anniversary break](benefits/paid_anniversary_break.md) – We celebrate your 3 and 5 year anniversary with us by buying your family a holiday
 
 Making work as fabulous as possible:
@@ -57,7 +57,7 @@ Compensating you fairly:
 
 * [Sick Leave](guides/welfare/sick_leave.md)
 * [State of Mind](guides/welfare/state_of_mind.md)
-* [Employee Assistance](guides/welfare/employee_assistance.md)
+* [Employee Assistance](guides/welfare/paid_counselling.md#employee-assistance)
 * [Expectations between Employees and the Organisation](guides/welfare/expectations.md)
 * [Raising an Issue](guides/welfare/raising_an_issue.md)
 * [Parental Leave](guides/welfare/parental_leave.md)

--- a/guides/welfare/paid_counselling.md
+++ b/guides/welfare/paid_counselling.md
@@ -1,4 +1,6 @@
-# Employee Assistance
+# Paid counselling
+
+## Employee Assistance
 
 We have setup an employee assistance programme to provide our team self-service access to all kinds of help. The confidential service provides:
 
@@ -12,11 +14,15 @@ We have setup an employee assistance programme to provide our team self-service 
 - Relationships (divorce & separation, counselling, bullying)
 - Addiction (substance and gambling, support for family, rehabilitation
 
-## Getting assistance
+### Getting assistance
 
 - **Online:** You can visit http://employeeassistance.org.uk to access help via the website. You'll find the password for access in our password manager.
 - **By phone:** You can call the 24/7 help line on 0800 328 1437
 
-## Confidentiality
+### Confidentiality
 
 We will be informed when the phone line and online service is used, and we will be alerted to what category of query/advice was made. We will not be provided any other details on the contents of your call or use of the service, nor will we be told who accessed the service.
+
+## Other options
+
+You are also welcome to pick your own therapist/counsellor. We can contribute up to £60 per session for the first 6 sessions.

--- a/guides/welfare/raising_an_issue.md
+++ b/guides/welfare/raising_an_issue.md
@@ -14,7 +14,7 @@ In particular, if you have a grievance you feel unable to raise with your mentor
 
 ## Seek Third Party Advice
 
-We provide staff access to a [employee wellbeing service](employee_assistance.md) which includes a phone number you can call for third party advice on HR issues.
+We provide staff access to a [employee wellbeing service](paid_counselling.md#employee-assistance) which includes a phone number you can call for third party advice on HR issues.
 
 You can also call the [Acas](http://www.acas.org.uk/index.aspx?articleid=2042) on 0300 123 1100, Monday-Friday 8am-6pm.
 

--- a/guides/welfare/sick_leave.md
+++ b/guides/welfare/sick_leave.md
@@ -10,7 +10,7 @@ When people get sick we ask that they follow these guidelines:
 
 * We can provide support if you need help with your [state of mind](state_of_mind.md).
 
-* If you need assistance with your sickness, you can use our [employee assistance programme](employee_assistance.md).
+* If you need assistance with your sickness, you can use our [employee assistance programme](paid_counselling.md#employee-assistance).
 
 * On your first day off, let your team know (Slack, email, etc.), or the operations team if you are on the Chalet, that you'll be away and what you had planned for that day. Aim to let them know as early as possible, by start of business, so they can factor your absence into their tasks for the day.
 

--- a/guides/welfare/state_of_mind.md
+++ b/guides/welfare/state_of_mind.md
@@ -11,5 +11,5 @@ We are a team and it is our duty to care for each other and ourselves, the latte
 - Take time off when you're not feeling great mentally
 - Ask a colleague, friend, family member for support or lend an ear if you can, sharing helps
 - If a colleague looks like they're struggling or need help, be extra kind and supportive, ask if they need help
-- If you want confidential advice or phone counselling you can use our [employee assistance programme](employee_assistance.md)
-- If you feel like you're really in trouble, please ask a director or colleague for help, we can provide assistance in whatever shape it need take, from extending time off to providing a course of counselling
+- If you want confidential advice or phone counselling you can use our [employee assistance programme](paid_counselling.md#employee-assistance)
+- If you feel like you're really in trouble, please ask a director or colleague for help, we can provide assistance in whatever shape it need take, from extending time off to providing a course of [counselling](paid_counselling.md)

--- a/roles/delivery_manager.md
+++ b/roles/delivery_manager.md
@@ -60,7 +60,7 @@ Balancing life and work:
 * 🗓️ [Flexible Working Days](../benefits/flexible_working.md) – We are flexible to the amount of days you work in a week
 * 👶 [Flexible Parental Leave](../guides/welfare/parental_leave.md) – We provide flexible parental leave options
 * 👩‍💻 [Remote Working](../benefits/remote_working.md) – We offer part-time remote working for all our staff
-* 🤗 [Paid counselling](../guides/welfare/employee_assistance.md) – We offer paid counselling as well as financial and legal advice
+* 🤗 [Paid counselling](../guides/welfare/paid_counselling.md) – We offer paid counselling as well as financial and legal advice
 * 🏖️ [Paid anniversary break](../benefits/paid_anniversary_break.md) – We celebrate your 3 and 5 year anniversary with us by buying your family a holiday
 
 Making work as fabulous as possible:

--- a/roles/lead_software_engineer.md
+++ b/roles/lead_software_engineer.md
@@ -70,7 +70,7 @@ Balancing life and work:
 * 🗓️ [Flexible Working Days](../benefits/flexible_working.md) – We are flexible to the amount of days you work in a week
 * 👶 [Flexible Parental Leave](../guides/welfare/parental_leave.md) – We provide flexible parental leave options
 * 👩‍💻 [Remote Working](../benefits/remote_working.md) – We offer part-time remote working for all our staff
-* 🤗 [Paid counselling](../guides/welfare/employee_assistance.md) – We offer paid counselling as well as financial and legal advice
+* 🤗 [Paid counselling](../guides/welfare/paid_counselling.md) – We offer paid counselling as well as financial and legal advice
 * 🏖️ [Paid anniversary break](../benefits/paid_anniversary_break.md) – We celebrate your 3 and 5 year anniversary with us by buying your family a holiday
 
 Making work as fabulous as possible:

--- a/roles/principal_technologist.md
+++ b/roles/principal_technologist.md
@@ -55,7 +55,7 @@ Balancing life and work:
 * 🗓️ [Flexible Working Days](../benefits/flexible_working.md) – We are flexible to the amount of days you work in a week
 * 👶 [Flexible Parental Leave](../guides/welfare/parental_leave.md) – We provide flexible parental leave options
 * 👩‍💻 [Remote Working](../benefits/remote_working.md) – We offer part-time remote working for all our staff
-* 🤗 [Paid counselling](../guides/welfare/employee_assistance.md) – We offer paid counselling as well as financial and legal advice
+* 🤗 [Paid counselling](../guides/welfare/paid_counselling.md) – We offer paid counselling as well as financial and legal advice
 * 🏖️ [Paid anniversary break](../benefits/paid_anniversary_break.md) – We celebrate your 3 and 5 year anniversary with us by buying your family a holiday
 
 Making work as fabulous as possible:

--- a/roles/senior_software_engineer.md
+++ b/roles/senior_software_engineer.md
@@ -68,7 +68,7 @@ Balancing life and work:
 * 🗓️ [Flexible Working Days](../benefits/flexible_working.md) – We are flexible to the amount of days you work in a week
 * 👶 [Flexible Parental Leave](../guides/welfare/parental_leave.md) – We provide flexible parental leave options
 * 👩‍💻 [Remote Working](../benefits/remote_working.md) – We offer part-time remote working for all our staff
-* 🤗 [Paid counselling](../guides/welfare/employee_assistance.md) – We offer paid counselling as well as financial and legal advice
+* 🤗 [Paid counselling](../guides/welfare/paid_counselling.md) – We offer paid counselling as well as financial and legal advice
 * 🏖️ [Paid anniversary break](../benefits/paid_anniversary_break.md) – We celebrate your 3 and 5 year anniversary with us by buying your family a holiday
 
 Making work as fabulous as possible:

--- a/roles/software_engineer_1.md
+++ b/roles/software_engineer_1.md
@@ -23,7 +23,7 @@ Balancing life and work:
 * 🗓️ [Flexible Working Days](../benefits/flexible_working.md) – We are flexible to the amount of days you work in a week
 * 👶 [Flexible Parental Leave](../guides/welfare/parental_leave.md) – We provide flexible parental leave options
 * 👩‍💻 [Remote Working](../benefits/remote_working.md) – We offer part-time remote working for all our staff
-* 🤗 [Paid counselling](../guides/welfare/employee_assistance.md) – We offer paid counselling as well as financial and legal advice
+* 🤗 [Paid counselling](../guides/welfare/paid_counselling.md) – We offer paid counselling as well as financial and legal advice
 * 🏖️ [Paid anniversary break](../benefits/paid_anniversary_break.md) – We celebrate your 3 and 5 year anniversary with us by buying your family a holiday
 
 Making work as fabulous as possible:

--- a/roles/software_engineer_2.md
+++ b/roles/software_engineer_2.md
@@ -23,7 +23,7 @@ Balancing life and work:
 * 🗓️ [Flexible Working Days](../benefits/flexible_working.md) – We are flexible to the amount of days you work in a week
 * 👶 [Flexible Parental Leave](../guides/welfare/parental_leave.md) – We provide flexible parental leave options
 * 👩‍💻 [Remote Working](../benefits/remote_working.md) – We offer part-time remote working for all our staff
-* 🤗 [Paid counselling](../guides/welfare/employee_assistance.md) – We offer paid counselling as well as financial and legal advice
+* 🤗 [Paid counselling](../guides/welfare/paid_counselling.md) – We offer paid counselling as well as financial and legal advice
 * 🏖️ [Paid anniversary break](../benefits/paid_anniversary_break.md) – We celebrate your 3 and 5 year anniversary with us by buying your family a holiday
 
 Making work as fabulous as possible:


### PR DESCRIPTION
On top of Employee Assistance, we also have the option of finding a therapist/counsellor ourselves, which Made Tech will help pay for - this PR adds this information to the handbook.

I've renamed the existing file, so that it's more generic: `paid_counselling` with `employee assistance` and `other options` sections, and updated links.


