### PR TITLE
Fix salary format across tech roles

### DIFF
--- a/roles/lead_software_engineer.md
+++ b/roles/lead_software_engineer.md
@@ -91,6 +91,8 @@ Compensating you fairly:
 
 ## Salary
 
+The salary for this role is location dependant:
+
 - Bristol: £63,900-£81,000
 - Manchester: £63,900-£81,000
 - London: £71,000-£90,000

--- a/roles/principal_technologist.md
+++ b/roles/principal_technologist.md
@@ -76,6 +76,8 @@ Compensating you fairly:
 
 ## Salary
 
+The salary for this role is location dependant:
+
 - Bristol: £81,900+
 - Manchester: £81,900+
 - London: £91,000+

--- a/roles/senior_software_engineer.md
+++ b/roles/senior_software_engineer.md
@@ -89,6 +89,8 @@ Compensating you fairly:
 
 ## Salary
 
+The salary for this role is location dependant:
+
 - Bristol: £45,900-£63,000
 - Manchester: £45,900-£63,000
 - London: £51,000-£70,000

--- a/roles/software_engineer_1.md
+++ b/roles/software_engineer_1.md
@@ -46,9 +46,9 @@ Compensating you fairly:
 
 The salary for this role is location dependant:
 
-*London:* £30000 to £39000
-*Manchester:* £27000 to £36000
-*Bristol:* £27000 to £36000
+- Bristol: £27,000-£36,000
+- Manchester: £27,000-£36,000
+- London: £30,000-£39,000
 
 ## Applying
 

--- a/roles/software_engineer_2.md
+++ b/roles/software_engineer_2.md
@@ -46,9 +46,9 @@ Compensating you fairly:
 
 The salary for this role is location dependant:
 
-*London:* £40000 to £50000
-*Manchester:* £36900 to £45000
-*Bristol:* £36900 to £45000
+- Bristol: £36,900-£45,000
+- Manchester: £36,900-£45,000
+- London: £40,000-£50,000
 
 ## Applying
 


### PR DESCRIPTION
I noticed that the format of the salary section in tech role descriptions was inconsistent:

The salary for this role is location dependant:
_London_: £xxxxx to £xxxxx _Manchester_: £xxxxx to £xxxxx _Bristol_: £xxxxx to £xxxxx

vs

Bristol: £xx,xxx
Manchester: £xx,xxx
London: £xx,xxx

I've updated these as follows:

The salary for this role is location dependant:
Bristol: £xx,xxx
Manchester: £xx,xxx
London: £xx,xxx


