### PR TITLE
Add Delivery Principal Page

### DIFF
--- a/roles/README.md
+++ b/roles/README.md
@@ -22,7 +22,7 @@ You may have also seen that we have people in Tech Lead and Tech Architect roles
 
 - [Delivery Manager](delivery_manager.md)
 - Senior Delivery Manager
-- Delivery Principal
+- [Delivery Principal](delivery_principal.md)
 - [Head of Delivery](head_of_delivery.md)
 
 ### Operations and Finance

--- a/roles/delivery_manager.md
+++ b/roles/delivery_manager.md
@@ -1,6 +1,6 @@
 # Delivery Manager
 
-Manchester & London, UK.
+Manchester, London, and Bristol UK.
 
 Please apply for this role at [www.madetech.com/careers](https://www.madetech.com/careers).
 

--- a/roles/delivery_principal.md
+++ b/roles/delivery_principal.md
@@ -1,0 +1,85 @@
+# Delivery Principal
+
+Manchester, London, and Bristol UK.
+
+Please apply for this role at [www.madetech.com/careers](https://www.madetech.com/careers).
+
+Our Delivery Principal help public sector organisations accelerate digital delivery, drive efficiency and ultimately improve society. They do this by leading large-scale teams (accounts), building and managing strategic relationships, finding new opportunities and advising as senior delivery leaders.
+
+## What does the job entail?
+
+At Made Tech we want to positively impact the future of the country by using technology to improve society. We help public sector organisations deliver quality software to help citizens get more from public services. To do this we work alongside brilliant public servants to modernise technology and accelerate digital delivery. 
+
+As a Delivery Principal you will be accountable for the successful delivery of a number of workstreams / teams within an account. You will focus on delivery assuring and supporting the teams, with emphasis on solving the difficult problems together with your teams, uncovering risks before they materialise and ensuring our deliveries adhere to the Made Tech delivery principles & standards. The teams will usually consist of a Delivery Manager, a Tech Lead and a number of engineers and although you will not be running the delivery day-to-day, you will assume the overall accountability at the account level and for all the workstreams within your account. 
+
+While this is not a hands-on delivery role, the importance of credibility in internet-era approaches to digital and technology in the public sector cannot be understated. You will be expected to maintain a broad knowledge of modern software delivery practices, be able to articulate benefits and debate use of different modern software development practices, and you will be expected to share this with both the wider customer and Made Tech businesses. 
+
+Working closely with our customers' senior leadership you will help inform their strategy and ensure our teams are delivering to a high quality and are aligned to our customers vision and goals. As part of an account team, alongside Tech and Client Leads, you will help shape account plans and be responsible for delivering against them. Working with Made Tech's regional and group leadership you will ensure our work with customers is aligned to our growth goals and you will play a pivotal role in identifying new opportunities and winning work. 
+
+You will coach and support our Delivery Managers to steer their team's towards success. You will also be responsible for hiring and line managing Delivery Managers in your regions.
+
+As a delivery leader within Made Tech you will be expected to maintain and grow your professional network. You will be expected to contribute to thought leadership, content and events and ideally, you will have a proven track record of doing so.
+
+
+## What we need from you
+
+While we will look for you to have experience in these things, if you don't have one of these don't let that stop you applying.
+
+- Working directly with customers and users
+- Working within a technology consultancy
+- Strong understanding of delivery assurance and effective ways of supporting teams
+- Strong understanding of agile ways of working
+- Strong understanding of modern software development practices
+- Evidence of self-development – we value keen learners
+- Drive to deliver outcomes for users
+- Desire to mentor others
+- Empathy and people skills
+
+*Optional experience*
+Don't forget to mention any of the experience listed below. While it's optional, it's all highly desired!
+
+- Working within an account or programme leadership team
+- Working within bid teams to win contracts
+- Working with multidisciplinary digital and technology teams
+- Working within the public sector
+- Experience in hiring, forming and running DM teams
+
+## What you will get from the role
+
+You will take ownership of the delivery function of a company that is rapidly scaling to meet increased customer demand, giving you exposure to a huge variety of enterprise-level, highly complex programmes with ever evolving challenges, whilst getting to work with a wealth of market-leading companies.
+
+As a technologically driven company that espouses best practice and aims to become a Thought Leader within the world of software delivery, Made Tech will provide you the opportunity to use the most exciting new technologies and to work in an environment where we are always striving to stay on the cutting-edge of market trends and processes.
+
+You'll have the chance to develop and adapt our agile processes, coaching both internal and external teams on best practice and designing workshops for building capabilities within customer organisations.
+
+## What we will provide you
+
+Balancing life and work:
+
+* ✈️ [Flexible Holiday](../benefits/flexible_holiday.md) – We trust you to take as much holiday as you need
+* 🕰️ [Flexible Working Hours](../benefits/working_hours.md) – We are flexible with what hours you work
+* 🗓️ [Flexible Working Days](../benefits/flexible_working.md) – We are flexible to the amount of days you work in a week
+* 👶 [Flexible Parental Leave](../guides/welfare/parental_leave.md) – We provide flexible parental leave options
+* 👩‍💻 [Remote Working](../benefits/remote_working.md) – We offer part-time remote working for all our staff
+* 🤗 [Paid counselling](../guides/welfare/paid_counselling.md) – We offer paid counselling as well as financial and legal advice
+* 🏖️ [Paid anniversary break](../benefits/paid_anniversary_break.md) – We celebrate your 3 and 5 year anniversary with us by buying your family a holiday
+
+Making work as fabulous as possible:
+
+* 💻 [Work Ready](../benefits/work_ready.md) – We'll buy you a Macbook, ergonomic equipment, books, conferences, training, and more
+* 💡 [Learn Tech](../guides/learning/README.md) – We spend every Friday afternoon learning rather than working
+* 🍽️ [Friday Lunches](../benefits/friday_lunch.md) – We randomly match up 8 colleagues every Friday and pay for lunch
+* 🍻 [Friday Drinks](../benefits/friday_drinks.md) – We pay for social drinks on a Friday
+
+Compensating you fairly:
+
+* 💷 [Transparent Salary Bands](../roles/README.md) – We publish salary bands so you know you're being fairly compensated
+* 👌 [Annual Salary Reviews](../guides/compensation/salary_reviews.md) – We review your salary on an annual basis
+* ⛷️ [Pension Scheme](../benefits/pension_scheme.md) – We provide a pension scheme so you can save for your future and we'll contribute to it
+* 🚄 [Season Ticket Loan](../benefits/season_ticket_loan.md) – We provide loans to help you pay for your travel
+* 🚲 [Cycle To Work Scheme](../benefits/cycle_to_work_scheme.md) – We offer the cycle to work scheme to help pay for your bicycle
+* 🚕 [Expenses Paid](../guides/compensation/expenses.md) – Taxi to a meeting? Want to take a customer to lunch? Expenses are no hassle!
+
+## Applying
+
+Please apply for this role at [www.madetech.com/careers](https://www.madetech.com/careers). If you don't quite fit the role, the role doesn't quite fit you, or you have questions please email us at [careers@madetech.com](mailto:careers@madetech.com) where we will be happy to help.

--- a/roles/delivery_principal.md
+++ b/roles/delivery_principal.md
@@ -4,7 +4,7 @@ Manchester, London, and Bristol UK.
 
 Please apply for this role at [www.madetech.com/careers](https://www.madetech.com/careers).
 
-Our Delivery Principal help public sector organisations accelerate digital delivery, drive efficiency and ultimately improve society. They do this by leading large-scale teams (accounts), building and managing strategic relationships, finding new opportunities and advising as senior delivery leaders.
+Our Delivery Principals help public sector organisations accelerate digital delivery, drive efficiency and ultimately improve society. They do this by leading large-scale teams (accounts), building and managing strategic relationships, finding new opportunities and advising as senior delivery leaders.
 
 ## What does the job entail?
 
@@ -79,6 +79,12 @@ Compensating you fairly:
 * 🚄 [Season Ticket Loan](../benefits/season_ticket_loan.md) – We provide loans to help you pay for your travel
 * 🚲 [Cycle To Work Scheme](../benefits/cycle_to_work_scheme.md) – We offer the cycle to work scheme to help pay for your bicycle
 * 🚕 [Expenses Paid](../guides/compensation/expenses.md) – Taxi to a meeting? Want to take a customer to lunch? Expenses are no hassle!
+## Salary
+
+The salary for this role is location dependant: 
+- Bristol: £73,000+ 
+- Manchester: £73,000+ 
+- London: £81,000+ 
 
 ## Applying
 


### PR DESCRIPTION
Added a dedicated page for the Delivery Principal role using content from the careers page.