### PR TITLE
First draft of annual review guidance

### DIFF
--- a/build.js
+++ b/build.js
@@ -17,14 +17,20 @@ function checkFile (fileName) {
       handleError(err)
 
       const baseUrl = `file://${path.dirname(path.resolve(fileName))}`
+      
+      const ignorePatterns = [
+        { pattern: /www.glassdoor.co.uk/ } // glassdoor returns 503 status to circle ci hosts
+      ]
 
-      markdownLinkCheck(md, { baseUrl }, (err, results) => {
+      markdownLinkCheck(md, { baseUrl, ignorePatterns }, (err, results) => {
         handleError(err)
 
         let hasErrored = false
 
         results.forEach(function (result) {
-          if (result.status !== 'alive') {
+          if (result.status === 'ignored') {
+            console.log(chalk.grey(' [' + chalk.yellow('%s') + '(%s)] %s'), result.status, result.statusCode, result.link)
+          } else if (result.status !== 'alive') {
             if (!hasErrored) {
               console.log('%s', fileName)
               hasErrored = true

--- a/guides/line-management/README.md
+++ b/guides/line-management/README.md
@@ -27,6 +27,8 @@ Hold a review once a year, reflecting on the year's highlights and challenges.
 This usually includes a salary review.
 This may include setting goals or themes for the coming year.
 
+[See more guidance on annual reviews](./annual_reviews.md)
+
 ### Promotions
 Help your direct report make a case for being promoted.
 

--- a/guides/line-management/annual_reviews.md
+++ b/guides/line-management/annual_reviews.md
@@ -1,0 +1,20 @@
+# Annual Reviews
+
+As a line manager, one of your responsibilities is to facilitate the annual reviews of the individuals you line manage. The annual review is a retrospective of the previous year, a look ahead at the coming year and typically a [salary review](../compensation/salary_reviews.md).
+
+## What should I do to prepare?
+
+It's recommended you advise and guide your reportee to collect and collate evidence of progress and growth continually through the review period. See [promotions](./promotions.md) for some guidance on this process, with the key difference being your goal ahead of the annual review is to show evidence of growth over the review period.
+
+Collate evidence from the review period in advance of the annual review date. In the same way as a promotion, your reportee is selling themselves, so you should guide them to do so and help build a compelling narrative for the Market Principal that highlights all the ways your reportee has excelled over the review period! Make sure to highlight growth against the SFIA attributes aligned to their role, and use feedback given and received to help build a clear picture.
+
+Contact the Market Principal for your reportee's region in advance of the annual review date, we recommend at least one calendar month, and share your collected evidence, preferably talking them through the individual's progress informally. This will help the Market Principal determine an appropriate salary review ahead of the review date and allow time for processing.
+
+You should also take the time to prepare a summary of the highlights and notable events of the review period to share with your reportee, and think about guidance and goals for the next review period.
+
+## The Annual Review
+
+The review itself should be a meeting where you are able to go through your prepared material with your reportee:
+ - Share the outcome of the salary review, if applicable.
+ - Recap the review period, and give your reportee the opportunity to share their reflections on how the year went
+ - Share your thoughts on the coming year, and give your reportee the opportunity to share their goals and desires

--- a/guides/line-management/annual_reviews.md
+++ b/guides/line-management/annual_reviews.md
@@ -6,15 +6,15 @@ As a line manager, one of your responsibilities is to facilitate the annual revi
 
 It's recommended you advise and guide your reportee to collect and collate evidence of progress and growth continually through the review period. See [promotions](./promotions.md) for some guidance on this process, with the key difference being your goal ahead of the annual review is to show evidence of growth over the review period.
 
-Collate evidence from the review period in advance of the annual review date. In the same way as a promotion, your reportee is selling themselves, so you should guide them to do so and help build a compelling narrative for the Market Principal that highlights all the ways your reportee has excelled over the review period! Make sure to highlight growth against the SFIA attributes aligned to their role, and use feedback given and received to help build a clear picture.
+In the same way as a promotion, your reportee is selling themselves, so you should guide them to do so and help build a compelling narrative for the Market Principal that highlights all the ways your reportee has excelled over the review period! Make sure to highlight growth against the SFIA attributes aligned to their role, and use feedback given and received to help build a clear picture.
 
 Contact the Market Principal for your reportee's region in advance of the annual review date, we recommend at least one calendar month, and share your collected evidence, preferably talking them through the individual's progress informally. This will help the Market Principal determine an appropriate salary review ahead of the review date and allow time for processing.
 
-You should also take the time to prepare a summary of the highlights and notable events of the review period to share with your reportee, and think about guidance and goals for the next review period.
+You should also take the time to prepare a summary of the highlights and notable events of the review period to share with your reportee, and think about guidance and goals for the next review period. Try to identify key areas of growth for the coming review period, constructive feedback from the individual's team and the Market Principal will be key to this.
 
 ## The Annual Review
 
 The review itself should be a meeting where you are able to go through your prepared material with your reportee:
  - Share the outcome of the salary review, if applicable.
  - Recap the review period, and give your reportee the opportunity to share their reflections on how the year went
- - Share your thoughts on the coming year, and give your reportee the opportunity to share their goals and desires
+ - Share your thoughts on the coming year and the key areas to focus on, and give your reportee the opportunity to share their goals and desires


### PR DESCRIPTION
This guide is intended to help line managers understand what they should prepare and do ahead of their reportees' annual reviews.

Dependant on https://github.com/madetech/handbook/pull/425 as references guidance written for promotions.