### PR TITLE
Clarify use of adoption leave alongside maternity and paternity leave

### DIFF
--- a/guides/welfare/parental_leave.md
+++ b/guides/welfare/parental_leave.md
@@ -1,26 +1,28 @@
-# Maternity, Paternity & Shared Parental Leave
+# Maternity, Paternity, Adoption & Shared Parental Leave
 
 Whether because you or your partner is having a baby, if you're adopting a child or having a baby through a surrogacy arrangement, Made Tech encourages you to take leave so that you can welcome the new child (or children!) into your family.
-Our paid Parental Leave is the same for all! 
+Our paid Parental Leave is the same for all!
 
 Note: You will have to be in employment with Made Tech for a minimum of 26 weeks to be eligible for these benefits.
 
-## Maternity Leave
+## Maternity and Adoption Leave
 
-We provide 12 weeks Maternity Leave at full pay followed by statutory pay for a further 39 weeks. You can take up to a total of 52 weeks.
+We provide 12 weeks Maternity/Adoption Leave at full pay followed by statutory pay for a further 39 weeks. You can take up to a total of 52 weeks.
+
+In the case of Adoption Leave, only one parent can take this type of leave. The other parent will need to take Paternity Leave or Shared Parental Leave.
 
 The breakdown of pay is as follows:
 
 - 12 weeks at 100% pay (from Made Tech)
-- 6 weeks at 90% pay (Statutory Maternity Pay)
-- 33 weeks at £151.20 or 90% pay which ever is lower (Statutory Maternity Pay)
+- 6 weeks at 90% pay (Statutory Maternity/Adoption Pay)
+- 33 weeks at £151.20 or 90% pay which ever is lower (Statutory Maternity/Adoption Pay)
 - return to work on reduced hours (30 hours) for 4 weeks on full pay to phase back into full time work
 
-There are detailed government guidelines here: [www.gov.uk/employers-maternity-pay-leave](https://www.gov.uk/employers-maternity-pay-leave).
+There are detailed government guidelines here: [www.gov.uk/employers-maternity-pay-leave](https://www.gov.uk/employers-maternity-pay-leave) and here: [https://www.gov.uk/employers-adoption-pay-leave](https://www.gov.uk/employers-adoption-pay-leave).
 
 ## Paternity Leave
 
-We provide 12 weeks Paternity Leave at full pay and the option of shared parental leave. The paternity leave must end within 56 days of the birth.
+We provide 12 weeks Paternity Leave at full pay and the option of shared parental leave. The leave must end within 56 days of the birth.
 
 The breakdown of pay is as follows:
 
@@ -38,12 +40,12 @@ The breakdown of pay is as follows if you qualify for SPL:
 - 12 weeks at 100% pay (from Made Tech)
 - 6 weeks at 90% pay (Statutory Maternity Pay)
 - 33 weeks at £151.20 or 90% pay which ever is lower (Statutory Maternity Pay)
-- return to work on reduced hours (30 hours) for 4 weeks on full pay to phase back into full time work 
+- return to work on reduced hours (30 hours) for 4 weeks on full pay to phase back into full time work
 
 The rules around SPL are fairly complex, government guidelines are available here: [https://www.gov.uk/shared-parental-leave-and-pay](https://www.gov.uk/shared-parental-leave-and-pay).
 
 ## Other Considerations
 
-We offer a number of additional company benefits which may be attractive to new parents, including [Remote Working](../../benefits/remote_working.md), [Untracked Holiday Allowance](../../benefits/flexible_holiday.md), [Flexible Work Weeks](../../benefits/flexible_working.md) and [Flexible Working Hours](../../benefits/working_hours.md). 
+We offer a number of additional company benefits which may be attractive to new parents, including [Remote Working](../../benefits/remote_working.md), [Untracked Holiday Allowance](../../benefits/flexible_holiday.md), [Flexible Work Weeks](../../benefits/flexible_working.md) and [Flexible Working Hours](../../benefits/working_hours.md).
 
 _Note: There is a strong desire to improve our offering, though we're currently constrained by our company size. As we grow and get a larger team and turnover, we're expecting to be able to make a more attractive package available_

--- a/guides/welfare/parental_leave.md
+++ b/guides/welfare/parental_leave.md
@@ -38,8 +38,8 @@ We provide 12 weeks Shared Parental Leave at full pay and up to 39 weeks at stat
 The breakdown of pay is as follows if you qualify for SPL:
 
 - 12 weeks at 100% pay (from Made Tech)
-- 6 weeks at 90% pay (Statutory Maternity Pay)
-- 33 weeks at £151.20 or 90% pay which ever is lower (Statutory Maternity Pay)
+- 6 weeks at 90% pay (Statutory Shared Parental Pay)
+- 33 weeks at £151.20 or 90% pay which ever is lower (Statutory Shared Parental Pay)
 - return to work on reduced hours (30 hours) for 4 weeks on full pay to phase back into full time work
 
 The rules around SPL are fairly complex, government guidelines are available here: [https://www.gov.uk/shared-parental-leave-and-pay](https://www.gov.uk/shared-parental-leave-and-pay).


### PR DESCRIPTION
Added some clarification about the use of adoption leave as we were previously only mentioning our offerings for maternity and paternity leave.