### PR TITLE
Update friday_lunch.md

### DIFF
--- a/benefits/friday_lunch.md
+++ b/benefits/friday_lunch.md
@@ -1,17 +1,11 @@
 # Friday Lunch
 
-Every Friday we pay for a team lunch.  This weekly ritual provides an opportunity for the team to socialise and share their successes and challenges from the week that's passed. It's important that we continue to set aside the time for this, especially when we have teams working at customers offices regularly.
+Every Friday we pay for 5 people from each region to have a team lunch. This weekly ritual provides an opportunity for the team to socialise and share their successes and challenges from the week that's passed. It's important that we continue to set aside the time for this, especially when we're all working remotely.
 
-Few rules:
+How it works:
+- the People team will organise lunches, inviting people from each region: you can only expense your lunch if invited to do so by them.
+- While we're working remotely, just order from your favourite restaurant (up to a maximum of £20) and be ready to start eating when lunch begins!
+- We'll look to resurrect our in-person lunches in each location when we start heading back to the office.
+- Any questions, ask your region's Community Manager
 
-* One of the directors will pick-up the tab for lunch. If we're not around, somebody with a company card should be able to cover lunch, or it can be put through as an expense claim. When expensing Friday lunch, choose the ‘Staff Meals’ account.
-
-* Generally we want everyone to eat together but if we go to a restaurant which excludes certain people like non-meateaters, meateaters and folk with other dietary requirements then a second option may be chosen and expensed. The majority of our restaurant list is friendly to all requirements :)
-
-* Whoever is involved in organising team lunch is responsible for ensuring that everyone who wants to eat can do so with respect to their dietary requirements.
-
-* If a work emergency comes up and keeps you from attending lunch you may order in and expense it and also request many merits from your colleagues for being a star!
-
-* We trust people to use their judgement as to what is a reasonable amount to spend on a team lunch.
-
-* Where possible, encourage customers to join us for lunch.
+Policy owners: Community Managers


### PR DESCRIPTION
Updating the handbook to reflect the current in-use policy that's been communicated in each market. We've outgrown the ability to make friday lunch available for everyone, and the lunchinator app on slack isn't being used so Community Managers own this at the moment. Feedback welcome on how we can evolve this going forward.