### PR TITLE
Update Learn Tech timesheeting

### DIFF
--- a/guides/process/scheduling/how_to_timesheet.md
+++ b/guides/process/scheduling/how_to_timesheet.md
@@ -40,7 +40,7 @@ Some categories should be used where there is significant time spent, i.e. 2 hou
 * Conferences - external events and conferences
 * Culture and happiness - assisting with the service area
 * Holidays - vacation time
-* Learn tech - if you are using part of your 12 day self-directed learning time budget.
+* Learning & development- if you are using part of your 12 day self-directed learning time budget.
 * Made Tech website - if you are participating in updates to the Made tech website
 * Marketing - assisting with marketing activities e.g. writing blogs, attending events
 * Onboarding - you are attending onboarding week

--- a/guides/process/scheduling/how_to_timesheet.md
+++ b/guides/process/scheduling/how_to_timesheet.md
@@ -40,7 +40,7 @@ Some categories should be used where there is significant time spent, i.e. 2 hou
 * Conferences - external events and conferences
 * Culture and happiness - assisting with the service area
 * Holidays - vacation time
-* Learning & development- if you are using part of your 12 day self-directed learning time budget.
+* Learning & development- if you are using part of your 12 day self-directed learning time budget
 * Made Tech website - if you are participating in updates to the Made tech website
 * Marketing - assisting with marketing activities e.g. writing blogs, attending events
 * Onboarding - you are attending onboarding week

--- a/guides/process/scheduling/how_to_timesheet.md
+++ b/guides/process/scheduling/how_to_timesheet.md
@@ -74,23 +74,24 @@ When you enter time, press the green save button at the bottom to save your time
 ## Timesheet approval process
 
 
-Once a team member has submitted their timesheet on Friday by 12pm, Delivery Managers and Service Area owners need to approve their teams timesheets by 1pm.
+Once a team member has submitted their timesheet on Friday by 12pm, Delivery Managers and Service Area owners need to approve their team's timesheets by 1pm.
 
-Why we need to approve timesheets
+### Why we need to approve timesheets
+
 Timesheet data directly drives our client invoicing, so it’s important it’s accurate and complete at the end of every week. It will also save you time when checking invoice accuracy at the end of the month. When approving timesheets for the week we need to:
 * Check your team has completed their timesheet in full; and has accurately recorded the time they spent on the project (inc. absences like illness and holidays)
 * Make sure their project codes are correct (inc. for unbilled time)
-* Account for any differences between the team’s Forecast time and their actual time spent and report this to the Operations team
+* Account for any differences between the team’s forecast time and their actual time spent and report this to the Operations team
 
 The review and approval process should take 5-10 minutes; and picking up any errors or unexplained differences saves the business a lot of time!
 Here are the instructions to approve someone's time:
 * In [Harvest](https://madetech.harvestapp.com/time/week) at the top select Time from the heading options
-* From the subheadings select Pending Approval
-* You can select the the 'Project', ‘People’ or ‘Week’ option from the dropdown menu at the top left to see your preferred view of the list of pending approvals
+* From the subheadings select `Pending Approval`
+* You can select the `Project`, `People` or `Week` option from the dropdown menu at the top left to see your preferred view of the list of pending approvals
 * This will list all of the client and internal projects, and the team members who have submitted their timesheet against these projects and are awaiting approval
-* <b><u>DO NOT</u> hit the "approve timesheets" button on the first page (i.e. for all team members)</b>
+* **<u>DO NOT</u> hit the "approve timesheets" button on the first page (i.e. for all team members)**
 * Under the project you're responsible for, select the team member whose timesheet you need to approve
-* If the time is correct, press Approve Timesheet at the bottom, this will only approve  the remaining projects will be approved by the project owner
+* If the time is correct, press `Approve Timesheet` at the bottom, this will only approve  the remaining projects will be approved by the project owner
 * Delivery Managers are responsible for approving Learning and Development time, absence and holiday, all of which should match up with time booked in CharlieHR
 
 We also ask that if you are going on holiday, that you allocate it to another Delivery Manager or senior member of the team. Scheduling can change this in Harvest, and change it back to you when you return

--- a/guides/process/scheduling/how_to_timesheet.md
+++ b/guides/process/scheduling/how_to_timesheet.md
@@ -71,6 +71,31 @@ For new team members joining mid-week, the total hours for the first week will b
 When you enter time, press the green save button at the bottom to save your timesheet.
 
 
+## Timesheet approval process
+
+
+Once a team member has submitted their timesheet on Friday by 12pm, Delivery Managers and Service Area owners need to approve their teams timesheets by 1pm.
+
+Why we need to approve timesheets
+Timesheet data directly drives our client invoicing, so it’s important it’s accurate and complete at the end of every week. It will also save you time when checking invoice accuracy at the end of the month. When approving timesheets for the week we need to:
+* Check your team has completed their timesheet in full; and has accurately recorded the time they spent on the project (inc. absences like illness and holidays)
+* Make sure their project codes are correct (inc. for unbilled time)
+* Account for any differences between the team’s Forecast time and their actual time spent and report this to the Operations team
+
+The review and approval process should take 5-10 minutes; and picking up any errors or unexplained differences saves the business a lot of time!
+Here are the instructions to approve someone's time:
+* In [Harvest](https://madetech.harvestapp.com/time/week) at the top select Time from the heading options
+* From the subheadings select Pending Approval
+* You can select the the 'Project', ‘People’ or ‘Week’ option from the dropdown menu at the top left to see your preferred view of the list of pending approvals
+* This will list all of the client and internal projects, and the team members who have submitted their timesheet against these projects and are awaiting approval
+* <b><u>DO NOT</u> hit the "approve timesheets" button on the first page (i.e. for all team members)</b>
+* Under the project you're responsible for, select the team member whose timesheet you need to approve
+* If the time is correct, press Approve Timesheet at the bottom, this will only approve  the remaining projects will be approved by the project owner
+* Delivery Managers are responsible for approving Learning and Development time, absence and holiday, all of which should match up with time booked in CharlieHR
+
+We also ask that if you are going on holiday, that you allocate it to another Delivery Manager or senior member of the team. Scheduling can change this in Harvest, and change it back to you when you return
+
+
 ## Contact us
 
 If you are unsure of where to put your time, especially for internal projects, please ask the Ops team in Slack using the #ops channel.

--- a/guides/process/scheduling/how_to_timesheet.md
+++ b/guides/process/scheduling/how_to_timesheet.md
@@ -2,21 +2,21 @@
 
 ## General
 
-Made Tech hours are 35 per week, 7 hours per day full time. Part-time hours are prorated and reflected in Harvest according to your agreed hours. 
+Made Tech hours are 35 per week, 7 hours per day full time. Part-time hours are prorated and reflected in Harvest according to your agreed hours.
 
 All billable team members need to complete a timesheet and you will be notified at your onboarding session if you need to complete one. The timesheet must be completed to account for all of your time in the working week. Non-billable staff (e.g. group functions like Operations, Marketing and People) do not need to complete one.
 
-Time can be completed in advance but in your unplanned absence your delivery manager can complete your timesheet. 
+Time can be completed in advance but in your unplanned absence your delivery manager can complete your timesheet.
 
 ## When to submit your time
 
 Time sheets need to be submitted weekly **every Friday by 12pm**. Weekly timesheets are more accurate, and we use the data to directly invoice our clients.
- 
-When the end of the month falls on a week day other than Friday, you will be asked to submit a timesheet up until the end of the month. This will be in addition to the Friday timesheet meaning you need to complete 2 in a week. 
 
-E.g. June 30 falls on a Tuesday, your timesheet needs to be submitted up until Tuesday i.e. 7 hours for Monday and 7 hours for Tuesday. The rest of the week (Wednesday to Friday) will be included in the Friday timesheet. 
+When the end of the month falls on a week day other than Friday, you will be asked to submit a timesheet up until the end of the month. This will be in addition to the Friday timesheet meaning you need to complete 2 in a week.
 
-Reminders are given through automated messages in Slack. 
+E.g. June 30 falls on a Tuesday, your timesheet needs to be submitted up until Tuesday i.e. 7 hours for Monday and 7 hours for Tuesday. The rest of the week (Wednesday to Friday) will be included in the Friday timesheet.
+
+Reminders are given through automated messages in Slack.
 
 ## What categories should I allocate my time to?
 
@@ -24,12 +24,12 @@ All of your 35 hours should be allocated to the category/ies where you spend you
 
 ## Client projects
 
-Client projects are separated into 3 categories; Billed, Investment and Chalet, you will be allocated to one as appropriate. 
+Client projects are separated into 3 categories; Billed, Investment and Chalet, you will be allocated to one as appropriate.
 
 ## Made Tech internal projects
 
 
-You may be on an internal project full time or in conjunction with a client project. These need to be added in the same way as a client project and your time needs to be input against these projects, not exceeding 35 hours in total. 
+You may be on an internal project full time or in conjunction with a client project. These need to be added in the same way as a client project and your time needs to be input against these projects, not exceeding 35 hours in total.
 
 Some categories should be used where there is significant time spent, i.e. 2 hours or more
 
@@ -40,7 +40,7 @@ Some categories should be used where there is significant time spent, i.e. 2 hou
 * Conferences - external events and conferences
 * Culture and happiness - assisting with the service area
 * Holidays - vacation time
-* Learn tech - every Friday 3.5 hours (unless a specified break in which case this is under absence). 
+* Learn tech - if you are using part of your 12 day self-directed learning time budget.
 * Made Tech website - if you are participating in updates to the Made tech website
 * Marketing - assisting with marketing activities e.g. writing blogs, attending events
 * Onboarding - you are attending onboarding week
@@ -51,24 +51,24 @@ Some categories should be used where there is significant time spent, i.e. 2 hou
 
 ## How to submit your timesheet
 
-Timesheets are submitted in Harvest, you will be given access on your first day. 
+Timesheets are submitted in Harvest, you will be given access on your first day.
 
-In the time tab at the top of the page toggle to the week section. 
+In the time tab at the top of the page toggle to the week section.
 
 If it’s your first time sheet, you will need to scroll down and select add row:
 
 
 A pop up window comes up for you to select from the drop down menu the client project you are currently working on including any Made Tech internal projects.
 
-To add additional projects, you need to select the + New Row button at the bottom indicated below. 
+To add additional projects, you need to select the + New Row button at the bottom indicated below.
 
 
 
 Once you have selected the projects they will be listed. In the week view you will need to input the number of hours spent on each client project including any Made Tech ones. Total time needs to add up to 35 hours for full time team members or agreed prorated hours.
 
-For new team members joining mid-week, the total hours for the first week will be what has been worked since you started i.e. 21 hours for 3 days. 
+For new team members joining mid-week, the total hours for the first week will be what has been worked since you started i.e. 21 hours for 3 days.
 
-When you enter time, press the green save button at the bottom to save your timesheet. 
+When you enter time, press the green save button at the bottom to save your timesheet.
 
 
 ## Contact us
@@ -81,7 +81,6 @@ If you are unsure of where to put your time, especially for internal projects, p
 
 **Billed** is where we are charging the client for your time and indicated by a ‘BIL’ in the project title.
 
-**Investment** is where we are investing time with the client but not charging them for your time, you are available should another suitable billed opportunity come up. This is indicated by a ‘INV’ in the project title. 
+**Investment** is where we are investing time with the client but not charging them for your time, you are available should another suitable billed opportunity come up. This is indicated by a ‘INV’ in the project title.
 
-**Chalet** is where you are not assigned to a client and are completely available for billed opportunities and internal projects. This is indicated by a ‘BEN’ in the project title. 
-
+**Chalet** is where you are not assigned to a client and are completely available for billed opportunities and internal projects. This is indicated by a ‘BEN’ in the project title.


### PR DESCRIPTION
Update the Learn Tech entry in "How to Timesheet" to reflect that we now have a 12 day annual budget for learning rather than defaulting to taking every Friday afternoon for it.

Also includes some whitespace linting but I can remove these if they're not wanted. 