### PR TITLE
Add page to assist employees with linking AWS certification accounts

### DIFF
--- a/build.js
+++ b/build.js
@@ -19,7 +19,8 @@ function checkFile (fileName) {
       const baseUrl = `file://${path.dirname(path.resolve(fileName))}`
       
       const ignorePatterns = [
-        { pattern: /www.glassdoor.co.uk/ } // glassdoor returns 503 status to circle ci hosts
+        { pattern: /www.glassdoor.co.uk/ },     // glassdoor returns 503 status to circle ci hosts
+        { pattern: /www.aws.training/ } 
       ]
 
       markdownLinkCheck(md, { baseUrl, ignorePatterns }, (err, results) => {

--- a/guides/cloud/aws_partner_certs.md
+++ b/guides/cloud/aws_partner_certs.md
@@ -1,0 +1,36 @@
+# AWS Partner Account Certification Linking
+
+## Purpose of this guide
+
+Made Tech are an [AWS Advanced Consulting Partner](https://partners.amazonaws.com/partners/001E0000016ppWOIAY/Made%20Tech) and require all Made Tech employees to create a user account within the AWS Partner Portal as part of their onboarding process for a number of reasons.
+ 1. Access to free AWS Partner Training materials.
+ 2. Linking employees personal AWS Certification accounts to our Partner account.
+
+# Accessing free AWS Partner Training materials
+
+AWS has an extensive Training and Certification framework, and there is a lot of great content we can utilise as an AWS Partner to develop and improve our knowledge when working with AWS services.
+
+We aim for every Made Tech employee to achieve the AWS Cloud Practitioner Certification, and the AWS Partner Portal provides some valuable free entry level training paths towards taking the Cloud Practitioner exam.
+
+The recommended AWS Partner training path for non-technical roles is the [AWS Business Professional](https://aws.amazon.com/partners/training/path-bus-pro/) and for technical roles the [AWS Technical Professional](https://aws.amazon.com/partners/training/path-tech-pro/).
+
+# AWS Certification account creation
+
+As a Made Tech employee you will be encouraged and supported in taking AWS Certifications. You are advised to create your AWS Certification account using a personal email address so any AWS Certifications you achieve belong to you. This can be the same Amazon account login that you use for doing your shopping on [Amazon](https://www.amazon.co.uk), so you maybe already have an account!
+
+There is a shared [login page](https://www.aws.training/SignIn) for both your personal Certification account and the Partner Portal. Use the left side login for your personal Certification area where you can book exams, and the right side to login to the AWS Partner Portal.
+
+This will land you on yet another page where you should click `Login to your account` and will eventually land you in your [Certmetrics Account](https://www.certmetrics.com/amazon/).
+
+Top tip - Every time you pass an AWS exam you receive a 50% off voucher for your next one in the [benefits tab](https://www.certmetrics.com/amazon/candidate/benefit_summary.aspx).
+
+# AWS Certification account linking
+
+In order for your AWS Certifications to appear within the Made Tech AWS Partner account, you need to create an account in the AWS Partner Portal using your Made Tech email address.
+
+1. Create an account in the [AWS Partner Central Portal](https://partnercentral.awspartner.com/APNSelfRegister) using your `firstname.lastname@madetech.com` email address.
+2. Click on `View My Profile` from the left hand `QUICK LINKS` menu.
+3. Click the blue `Edit` button.
+4. Under `AWS CERTIFICATION` add your personal AWS Certification email address to the `AWS T&C Account Email` field, and select `Yes` for `I consent to share my AWS Certifications with "Made Tech" *`
+
+Your AWS Certifications will not immediately appear, so check back at a later date.

--- a/guides/cloud/aws_partner_certs.md
+++ b/guides/cloud/aws_partner_certs.md
@@ -6,7 +6,7 @@ Made Tech are an [AWS Advanced Consulting Partner](https://partners.amazonaws.co
  1. Access to free AWS Partner Training materials.
  2. Linking employees personal AWS Certification accounts to our Partner account.
 
-# Accessing free AWS Partner Training materials
+## Accessing free AWS Partner Training materials
 
 AWS has an extensive Training and Certification framework, and there is a lot of great content we can utilise as an AWS Partner to develop and improve our knowledge when working with AWS services.
 
@@ -14,7 +14,7 @@ We aim for every Made Tech employee to achieve the AWS Cloud Practitioner Certif
 
 The recommended AWS Partner training path for non-technical roles is the [AWS Business Professional](https://aws.amazon.com/partners/training/path-bus-pro/) and for technical roles the [AWS Technical Professional](https://aws.amazon.com/partners/training/path-tech-pro/).
 
-# AWS Certification account creation
+## AWS Certification account creation
 
 As a Made Tech employee you will be encouraged and supported in taking AWS Certifications. You are advised to create your AWS Certification account using a personal email address so any AWS Certifications you achieve belong to you. This can be the same Amazon account login that you use for doing your shopping on [Amazon](https://www.amazon.co.uk), so you maybe already have an account!
 
@@ -24,11 +24,11 @@ This will land you on yet another page where you should click `Login to your acc
 
 Top tip - Every time you pass an AWS exam you receive a 50% off voucher for your next one in the [benefits tab](https://www.certmetrics.com/amazon/candidate/benefit_summary.aspx).
 
-# AWS Certification account linking
+## AWS Certification account linking
 
 In order for your AWS Certifications to appear within the Made Tech AWS Partner account, you need to create an account in the AWS Partner Portal using your Made Tech email address.
 
-1. Create an account in the [AWS Partner Central Portal](https://partnercentral.awspartner.com/APNSelfRegister) using your `firstname.lastname@madetech.com` email address.
+1. Create an account in the [AWS Partner Central Portal](https://partnercentral.awspartner.com/APNSelfRegister) using your `@madetech.com` email address.
 2. Click on `View My Profile` from the left hand `QUICK LINKS` menu.
 3. Click the blue `Edit` button.
 4. Under `AWS CERTIFICATION` add your personal AWS Certification email address to the `AWS T&C Account Email` field, and select `Yes` for `I consent to share my AWS Certifications with "Made Tech" *`


### PR DESCRIPTION
Add page to assist employees with linking AWS certification accounts to our partner account