### PR TITLE
Add guidance around hiring contractors

### DIFF
--- a/build.js
+++ b/build.js
@@ -20,7 +20,9 @@ function checkFile (fileName) {
       
       const ignorePatterns = [
         { pattern: /www.glassdoor.co.uk/ },     // glassdoor returns 503 status to circle ci hosts
-        { pattern: /www.aws.training/ } 
+        { pattern: /www.aws.training/ },
+        { pattern: /made-tech.workable.com/ },
+        { pattern: /docs.google.com/ } // Internal docs are hidden and will cause errors sometimes
       ]
 
       markdownLinkCheck(md, { baseUrl, ignorePatterns }, (err, results) => {

--- a/guides/process/scheduling/hiring_contractors.md
+++ b/guides/process/scheduling/hiring_contractors.md
@@ -63,6 +63,7 @@ Definition of Hiring Manager: The person responsible for the contractor.
    Scheduling will check that the current project does not need them further, if there are no known opportunities, they will then offer this role out to all markets in Slack. If there are no needs, the People team will be contacted to serve their contract notice period.
 
   **How is notice served? Can I terminate a contractor earlier than the agreed end date?** 
+  
   Please inform the Scheduling team as soon as you anticipate a contractor will no longer needed on the project. We usually set an expectation of 1 calendar weeks’ notice but this is contract dependent so please check beforehand with Scheduling. 
 
   This will be initiated with the People team who manage contracts and will inform the agency if required. 
@@ -72,7 +73,9 @@ Definition of Hiring Manager: The person responsible for the contractor.
 
   
 
-  **Who should decide if a contractor can be unbilled for a certain period and who pays for this time?** Contractors should not be unbilled and we expect them to be working 5-days a week on client-work, except where we have agreed an onboarding period of half a day or where there is Market Principal approval. The start date needs to be agreed with the client and communicated to the contractor. If there’s any change in start date, the contractor should start in line with that date and should be informed if this change. The contract will also need to be updated. There should not be a period where the contractor is unbilled. Where there is a break between projects, the contractor will be asked to take holiday in between. 
+  **Who should decide if a contractor can be unbilled for a certain period and who pays for this time?** 
+  
+  Contractors should not be unbilled and we expect them to be working 5-days a week on client-work, except where we have agreed an onboarding period of half a day or where there is Market Principal approval. The start date needs to be agreed with the client and communicated to the contractor. If there’s any change in start date, the contractor should start in line with that date and should be informed if this change. The contract will also need to be updated. There should not be a period where the contractor is unbilled. Where there is a break between projects, the contractor will be asked to take holiday in between. 
 
 
 

--- a/guides/process/scheduling/hiring_contractors.md
+++ b/guides/process/scheduling/hiring_contractors.md
@@ -1,0 +1,79 @@
+# HOW TO HIRE A CONTRACTOR
+
+Definition of contractor: An externally sourced individual Off-payroll worker, working to deliver specific outcomes on a single client project for a predetermined length of time.
+
+Definition of Hiring Manager: The person responsible for the contractor. 
+
+**This process is for when it is highly likely that there are no internal capability for a skillset available for a project. As per usual process, this should be determined in conjunction with Scheduling before this process kicks off.** 
+
+1. To initiate a request with the Talent team, [This form](https://docs.google.com/forms/d/1HgIwXsW80r2RIpD0T4Oj6nHXsjOvoRF41CuJ9mHY4X0/edit) will need to be completed. Scheduling will work with you to fill this out. 
+   * [from May 2021- the Scheduling team will complete an IR35 assessment to define whether the role falls inside or outside of IR35].
+
+2. The Talent team will source appropriate CVs and upload them to [Workable](https://made-tech.workable.com/backend) (our internal applicant tracking system) and tag the Hiring Manager for evaluation feedback on the system. 
+3. Once the CV’s have been evaluated and feedback uploaded to Workable, the Talent team will arrange and confirm interviews with the Hiring Manager. It’s advisable to block out some slots in your diary and loop in the appropriate persons to interview candidate capability beforehand to keep pace with the hiring process. 
+4. Once you have decided to offer a candidate, please inform the Talent team so they can relay feedback correctly and negotiate the offer where necessary. 
+5. When we have an accepted offer and start date, the People team will complete the administration and contract, the Scheduling team will be kept informed. 
+   * [from May - When a contractor begins work, they must complete an IR35 re-assessment to confirm the in-practice IR35 status of the role.]
+
+## Points to consider
+
+* The client project team are responsible for the contractor. 
+
+* It is the project team’s responsibility to inform the Scheduling team of the contractor’s end date so that the contract notice can be served in time
+
+* Billable contractors need to complete a Made Tech timesheet. This may be in addition to the agency timesheet. 
+
+* Line managers are responsible for the accuracy of both timesheets.
+
+* Contractors cannot be unbilled or in the chalet without written approval from the relevant Market Principal.
+
+* Contractors must be attached to a single, specific project and set of outcomes. To transfer a contractor to a new project, a new assessment must be done and **a new contract must be issued** to remain IR35 compliant. The Scheduling team will facilitate this change in contract with the People Team
+
+* Contractors must carry out the work specified in their contract i.e lead engineer for HMRC. They are not able to work on internal projects or work for other Made Tech clients without this agreed and the contract adjusted to reflect this arrangement.
+
+* If there is a known break between projects i.e one project finishes and there’s a 2 week break, the contractor should take this time as unbilled leaved. The People team can support these conversations.
+
+  ## FAQs
+
+  **What are contractors permitted to do (and not do) whilst with Made Tech?**
+
+  Contractors **shouldn’t be required** to attend company updates or social events, however they may be invited and go of their own accord. 
+
+  They shouldn’t receive training, line manage anyone or, work on multiple projects at one time. However, it is acceptable to share knowledge or train the team. 
+
+  Contractors should not work on internal projects whilst contracted to work on client projects due to IR35 legal requirements. This is also cost prohibitive. If the scope of work, client or other elements of their contract e.g. hours, days, day rate, changes, we need to update the contract to reflect this. Please inform scheduling asap in case this affects financial reporting and the systems need amending. 
+
+  
+
+  **Who are the right people to interview for these roles to ensure we are getting the right skills for the project?** 
+
+  The project teams will be expected to interview contractors because they sit outside of the standard hiring process and there’s an urgency to the request. If the project lead (tech lead or delivery manager) would like specific expertise, Scheduling can help to determine the right person in the business to request time from. 
+
+  
+
+  **Who determines the contractor rates and makes a decision on margin?** 
+
+  The rate for the role must be included in the contractor request form. The Talent team will use this as a guide to understand maximum limits for a role, however, will use market rates for a role and the charge out rate will not be shared with an agency or candidate. 
+  Using the [rate card and calculator](https://docs.google.com/spreadsheets/d/11LkRvm5gGnSeAxp_3i1H-_jlfWWpqXEM3Xz5SLAeVRE/edit#gid=368177954), you can see if a candidate falls within the acceptable range, and if not, it will need a decision from the project lead and Market Principal. For any additional evidence or questions around market information, please contact the talent team.  
+
+  
+
+  **Who is responsible for finding contractors other opportunities within the business and managing either their notice or contract change/extension?**
+
+   Scheduling will check that the current project does not need them further, if there are no known opportunities, they will then offer this role out to all markets in Slack. If there are no needs, the People team will be contacted to serve their contract notice period.
+
+  **How is notice served? Can I terminate a contractor earlier than the agreed end date?** 
+  Please inform the Scheduling team as soon as you anticipate a contractor will no longer needed on the project. We usually set an expectation of 1 calendar weeks’ notice but this is contract dependent so please check beforehand with Scheduling. 
+
+  This will be initiated with the People team who manage contracts and will inform the agency if required. 
+  If a project unexpectedly finishes, we may be liable to pay the notice period. Where there is a financial impact to Made Tech, the Market Principal needs to be informed. 
+
+  We should aim to give the contractor as much notice as possible that the project is coming to an end. 
+
+  
+
+  **Who should decide if a contractor can be unbilled for a certain period and who pays for this time?** Contractors should not be unbilled and we expect them to be working 5-days a week on client-work, except where we have agreed an onboarding period of half a day or where there is Market Principal approval. The start date needs to be agreed with the client and communicated to the contractor. If there’s any change in start date, the contractor should start in line with that date and should be informed if this change. The contract will also need to be updated. There should not be a period where the contractor is unbilled. Where there is a break between projects, the contractor will be asked to take holiday in between. 
+
+
+
+For any other questions not covered please refer to the [Ops Scheduling Slack Channel](https://madetechteam.slack.com/archives/CFCSJJVML). 


### PR DESCRIPTION
Brings in the change from #473 as well as ignores any links added that cause build failures