### PR TITLE
Add link to FAQ for learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Balancing life and work:
 Making work as fabulous as possible:
 
 * 💻 [Work Ready](benefits/work_ready.md) – We'll buy you a Macbook, ergonomic equipment, books, conferences, training, and more
-* 💡 [Learn Tech](guides/learning/README.md) – We provide flexible learning time to develop yourself
+* 💡 [Learning](guides/learning/README.md) – We provide flexible learning time to develop yourself
 * 🍽️ [Friday Lunches](benefits/friday_lunch.md) – We randomly match up 8 colleagues every Friday and pay for lunch
 * 🍻 [Friday Drinks](benefits/friday_drinks.md) – We pay for social drinks on a Friday
 

--- a/guides/learning/README.md
+++ b/guides/learning/README.md
@@ -36,3 +36,9 @@ Our Engineering team has built some Core Skills, which are courses around topics
 Currently, each Core Skill is comprised of 3 levels, with acompanying stickers (which you will see on people's laptops).
 
 You earn these stickers by doing coursework, or by passing an assessment, set by members of the Engineering team with expertise in that skill.
+
+
+## FAQs
+
+Please click on this link for frequently asked questions regarding your learning at Made Tech: 
+[FAQ](https://docs.google.com/document/d/14tdHZ72DXzZTwWLGwz6DoaSV1EXSI6D2K4lUY1dCGTY/edit?usp=sharing)


### PR DESCRIPTION
## What 

Added google doc link for FAQ, for internal employees

## Why

Due to changes with how learn has evolved at Made Tech, lots of questions have been asked and the answers are found here.