### PR TITLE
Remove references to Learn Tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Compensating you fairly:
 #### Team
 
 * [Team Norms](team-norms)
-* [Learning & Learn Tech](guides/learning)
+* [Learning](guides/learning)
 * [Mentorship](guides/mentorship)
 * [Marketing Assets](https://github.com/madetech/marketing-assets)
 * [3rd Party Expenses](guides/3rd_party_services.md)

--- a/benefits/remote_working.md
+++ b/benefits/remote_working.md
@@ -14,7 +14,7 @@ There are tradeoffs when choosing between working from the office and from home.
 - Be a good Slack citizen and check in regularly and visibly with your team throughout the working day in public channels
 - Ensure you're clear on your workload for the day or days you wish to work from home and ensure that you won't benefit from working closely with others
 - Ensure you're not scheduled for any meetings or sessions
-- Barring any extraordinary circumstances, we like people to be in the office on Friday for [lunch](friday_lunch.md) and Learn Tech
+- Barring any extraordinary circumstances, we like people to be in the office on Friday
 
 ### Regular Remote Working
 

--- a/guides/process/scheduling/how_to_timesheet.md
+++ b/guides/process/scheduling/how_to_timesheet.md
@@ -28,12 +28,11 @@ Client projects are separated into 3 categories; Billed, Investment and Chalet, 
 
 ## Made Tech internal projects
 
-
 You may be on an internal project full time or in conjunction with a client project. These need to be added in the same way as a client project and your time needs to be input against these projects, not exceeding 35 hours in total.
 
 Some categories should be used where there is significant time spent, i.e. 2 hours or more
 
-* Absence - sick leave and a specified break from Learn Tech
+* Absence - sick leave
 * Academy - assisting with the academy programme
 * Certifications (chalet) - currently studying for a certification
 * Chalet - you are not currently on a project and are available

--- a/guides/process/scheduling/setting_up_projects.md
+++ b/guides/process/scheduling/setting_up_projects.md
@@ -34,7 +34,7 @@ Sometimes we collaborate with partner organisations. If that partner organisatio
 
 ### Internal initiatives
 
-If we're working on an internal initiative, such as a Service Area, Learn Tech, or running an internal project within a Market, there are a number of internal clients:
+If we're working on an internal initiative, such as a Service Area, or running an internal project within a Market, there are a number of internal clients:
 
 - Made Tech: this client is reserved for group-wide activities such as Service Areas, Holidays, Absence etc.
 
@@ -57,7 +57,7 @@ There are a number of components to a project code:
 A three letter code identifying the location of the project:
 
 - GRP - group (typically Service Areas)
-- NOL - no location (e.g. paid time off, absence, Learn Tech)
+- NOL - no location (e.g. paid time off, absence)
 - LDN - London
 - MCR - Manchester
 - BRS - Bristol

--- a/roles/delivery_manager.md
+++ b/roles/delivery_manager.md
@@ -66,7 +66,7 @@ Balancing life and work:
 Making work as fabulous as possible:
 
 * 💻 [Work Ready](../benefits/work_ready.md) – We'll buy you a Macbook, ergonomic equipment, books, conferences, training, and more
-* 💡 [Learn Tech](../guides/learning/README.md) – We spend every Friday afternoon learning rather than working
+* 💡 [Learning](../guides/learning/README.md) – We offer 12 days per year of personal learning time and a £300 personal learning budget
 * 🍽️ [Friday Lunches](../benefits/friday_lunch.md) – We randomly match up 8 colleagues every Friday and pay for lunch
 * 🍻 [Friday Drinks](../benefits/friday_drinks.md) – We pay for social drinks on a Friday
 

--- a/roles/delivery_principal.md
+++ b/roles/delivery_principal.md
@@ -67,7 +67,7 @@ Balancing life and work:
 Making work as fabulous as possible:
 
 * 💻 [Work Ready](../benefits/work_ready.md) – We'll buy you a Macbook, ergonomic equipment, books, conferences, training, and more
-* 💡 [Learn Tech](../guides/learning/README.md) – We spend every Friday afternoon learning rather than working
+* 💡 [Learning](../guides/learning/README.md) – We offer 12 days per year of personal learning time and a £300 personal learning budget
 * 🍽️ [Friday Lunches](../benefits/friday_lunch.md) – We randomly match up 8 colleagues every Friday and pay for lunch
 * 🍻 [Friday Drinks](../benefits/friday_drinks.md) – We pay for social drinks on a Friday
 

--- a/roles/lead_software_engineer.md
+++ b/roles/lead_software_engineer.md
@@ -76,7 +76,7 @@ Balancing life and work:
 Making work as fabulous as possible:
 
 * 💻 [Work Ready](../benefits/work_ready.md) – We'll buy you a Macbook, ergonomic equipment, books, conferences, training, and more
-* 💡 [Learn Tech](../guides/learning/README.md) – We spend every Friday afternoon learning rather than working
+* 💡 [Learning](../guides/learning/README.md) – We offer 12 days per year of personal learning time and a £300 personal learning budget
 * 🍽️ [Friday Lunches](../benefits/friday_lunch.md) – We randomly match up 8 colleagues every Friday and pay for lunch
 * 🍻 [Friday Drinks](../benefits/friday_drinks.md) – We pay for social drinks on a Friday
 

--- a/roles/principal_technologist.md
+++ b/roles/principal_technologist.md
@@ -61,7 +61,7 @@ Balancing life and work:
 Making work as fabulous as possible:
 
 * 💻 [Work Ready](../benefits/work_ready.md) – We'll buy you a Macbook, ergonomic equipment, books, conferences, training, and more
-* 💡 [Learn Tech](../guides/learning/README.md) – We spend every Friday afternoon learning rather than working
+* 💡 [Learning](../guides/learning/README.md) – We offer 12 days per year of personal learning time and a £300 personal learning budget
 * 🍽️ [Friday Lunches](../benefits/friday_lunch.md) – We randomly match up 8 colleagues every Friday and pay for lunch
 * 🍻 [Friday Drinks](../benefits/friday_drinks.md) – We pay for social drinks on a Friday
 

--- a/roles/senior_software_engineer.md
+++ b/roles/senior_software_engineer.md
@@ -74,7 +74,7 @@ Balancing life and work:
 Making work as fabulous as possible:
 
 * 💻 [Work Ready](../benefits/work_ready.md) – We'll buy you a Macbook, ergonomic equipment, books, conferences, training, and more
-* 💡 [Learn Tech](../guides/learning/README.md) – We spend every Friday afternoon learning rather than working
+* 💡 [Learning](../guides/learning/README.md) – We offer 12 days per year of personal learning time and a £300 personal learning budget
 * 🍽️ [Friday Lunches](../benefits/friday_lunch.md) – We randomly match up 8 colleagues every Friday and pay for lunch
 * 🍻 [Friday Drinks](../benefits/friday_drinks.md) – We pay for social drinks on a Friday
 

--- a/roles/sfia/senior_software_engineer.md
+++ b/roles/sfia/senior_software_engineer.md
@@ -38,7 +38,7 @@ Below are examples of behaviours and responsibilities a person in this role migh
 - Pairs with and coaches junior members of the team and/or customer staff, supporting line managers to find career progression opportunities within the workstream
 - Able to lead a bootup and delivery of a product workstream where outcomes are known, and the product is complicated rather than complex, with support and coaching from a Lead
 - Continues to seek consensus with approaches, and feedback on work as it is iteratively delivered
-- Confidently facilitates retrospectives and other team ceremonies regularly, and delivers Learn Tech showcases
+- Confidently facilitates retrospectives and other team ceremonies regularly, and delivers Showcases
 - Has strong awareness of how Made Tech is perceived by customers and partners, as well as how colleagues and themselves are perceived by other colleagues. Will provide direct performance data and feedback in order to rectify the situation
 - Plays an active part in evolving Made Tech's approach to modern technology delivery
 - Identifies performance issues within the workstream team and works with individuals and line managers supporting corrective action where necessary

--- a/roles/software_engineer_1.md
+++ b/roles/software_engineer_1.md
@@ -29,7 +29,7 @@ Balancing life and work:
 Making work as fabulous as possible:
 
 * 💻 [Work Ready](../benefits/work_ready.md) – We'll buy you a Macbook, ergonomic equipment, books, conferences, training, and more
-* 💡 [Learn Tech](../guides/learning/README.md) – We spend every Friday afternoon learning rather than working
+* 💡 [Learning](../guides/learning/README.md) – We offer 12 days per year of personal learning time and a £300 personal learning budget
 * 🍽️ [Friday Lunches](../benefits/friday_lunch.md) – We randomly match up 8 colleagues every Friday and pay for lunch
 * 🍻 [Friday Drinks](../benefits/friday_drinks.md) – We pay for social drinks on a Friday
 

--- a/roles/software_engineer_2.md
+++ b/roles/software_engineer_2.md
@@ -58,7 +58,7 @@ Balancing life and work:
 Making work as fabulous as possible:
 
 * 💻 [Work Ready](../benefits/work_ready.md) – We'll buy you a Macbook, ergonomic equipment, books, conferences, training, and more
-* 💡 [Learn Tech](../guides/learning/README.md) – We spend every Friday afternoon learning rather than working
+* 💡 [Learning](../guides/learning/README.md) – We offer 12 days per year of personal learning time and a £300 personal learning budget
 * 🍽️ [Friday Lunches](../benefits/friday_lunch.md) – We randomly match up 8 colleagues every Friday and pay for lunch
 * 🍻 [Friday Drinks](../benefits/friday_drinks.md) – We pay for social drinks on a Friday
 

--- a/team-norms/timesheets.md
+++ b/team-norms/timesheets.md
@@ -21,8 +21,6 @@ The good news is that at Made Tech, Engineers are dedicated to one engagement at
 
 - *Project*: by default you're likely to be focused on a single engagement at any one time, and so you should timesheet 7 hours per working day against this engagement
 
-- *Learn Tech*: if you partake in Learn Tech you should timesheet 3.5 hours on a Friday afternoon against Learn Tech, and 3.5 hours against your current engagement
-
 - *Holidays*: prior to heading off on holiday, as well as completing any outstanding timesheets, and putting your out of office autoresponder on, you must proactively complete timesheets for the duration of your holiday, booking your time against Made Tech -> Holiday
 
 - *Absence*: when returning from a period of absence (e.g. sickness, hospital appointment, compassionate leave), you must update your timesheet to reflect that you were absent. If you're absent on a Friday or the last of the month, your Delivery Lead will be expected to complete a timesheet on your behalf. You should book your time against Made Tech -> Absence


### PR DESCRIPTION
Bit out housekeeping around references to Learn Tech around the handbook. I noticed whilst adding a new role and did a wee grep around.