### PR TITLE
Add Diversity and Inclusion teams and communities to Handbook

### DIFF
--- a/guides/equality-diversity-and-inclusion/README.md
+++ b/guides/equality-diversity-and-inclusion/README.md
@@ -12,7 +12,7 @@ Read our [Equality, Diversity & Inclusion Policy](policy.md).
 
 We have a number of ways we support equality, diversity and inclusion at Made Tech.
 
-We have a [diversity and inclusion service team](about-service-team.md) who are responsible for defining our strategy, setting KPIs and objectives, supporting the wider organisation to take action to deliver on these objectives, and reporting on progress to our leadership team. This team is an escalation point for D&I related issues and manages the operation of equality data collection and reporting. 
+We have a [diversity and inclusion service team](about-service-team.md) who are responsible for defining our strategy, setting KPIs and objectives, supporting the wider organisation to take action to deliver on these objectives, and reporting on progress to our leadership team and the wider company. This team is an escalation point for D&I related issues and manages the operation of equality data collection and reporting. 
 
 We have a regular forum, our diversity and inclusion community meetup for discussing diversity and inclusion matters, scrutinising decisions being made by the diversity and inclusion service team, and making suggestions for future strategy.
 

--- a/guides/equality-diversity-and-inclusion/README.md
+++ b/guides/equality-diversity-and-inclusion/README.md
@@ -12,7 +12,7 @@ Read our [Equality, Diversity & Inclusion Policy](policy.md).
 
 We have a number of ways we support equality, diversity and inclusion at Made Tech.
 
-We have a diversity and inclusion service team who are responsible for defining our strategy, setting KPIs and objectives, supporting the wider organisation to take action to deliver on these objectives, and reporting on progress to our leadership team. This team is an escalation point for D&I related issues and manages the operation of equality data collection and reporting. 
+We have a [diversity and inclusion service team](about-service-team.md) who are responsible for defining our strategy, setting KPIs and objectives, supporting the wider organisation to take action to deliver on these objectives, and reporting on progress to our leadership team. This team is an escalation point for D&I related issues and manages the operation of equality data collection and reporting. 
 
 We have a regular forum, our diversity and inclusion community meetup for discussing diversity and inclusion matters, scrutinising decisions being made by the diversity and inclusion service team, and making suggestions for future strategy.
 

--- a/guides/equality-diversity-and-inclusion/README.md
+++ b/guides/equality-diversity-and-inclusion/README.md
@@ -8,3 +8,12 @@ We recognise that our different backgrounds, experiences, views, beliefs, cultur
 
 Read our [Equality, Diversity & Inclusion Policy](policy.md).
 
+## Teams and communities
+
+We have a number of ways we support equality, diversity and inclusion at Made Tech.
+
+We have a diversity and inclusion service team who are responsible for defining our strategy, setting KPIs and objectives, supporting the wider organisation to take action to deliver on these objectives, and reporting on progress to our leadership team. This team is an escalation point for D&I related issues and manages the operation of equality data collection and reporting. 
+
+We have a regular forum, our diversity and inclusion community meetup for discussing diversity and inclusion matters, scrutinising decisions being made by the diversity and inclusion service team, and making suggestions for future strategy.
+
+We support open and closed community groups that meet to share experiences, raise issues and promote various aspects of diversity and inclusion. Open communities are free for anyone to join while closed communities are available to join by invite if you identify as belonging to that community.

--- a/guides/equality-diversity-and-inclusion/about-service-team.md
+++ b/guides/equality-diversity-and-inclusion/about-service-team.md
@@ -1,0 +1,34 @@
+# Diversity and inclusion service team
+
+The diversity and inclusion service team are responsible for and empowered to shape and deliver changes to drive improvements that lead to Made Tech being a more diverse and inclusive place to work. We see this as a necessary ongoing investment needed to ensure equal opportunities are brought about by our work and that we maintain an inclusive culture as we grow.
+
+Specifically, the diversity and inclusion service team is funded to and is responsible for:
+
+- Defining our strategy
+- Setting KPIs and objectives
+- Co-creating change plans with other service teams
+- Supporting the wider organisation to take action to deliver on these objectives
+- Reporting on progress to our leadership team
+- Being an escalation point with the ability to raise issues at an executive and board-level
+- Manage operation of equality data collection
+- Reporting on equality data to drive future decisions and investments
+- Running the diversity and inclusion community
+- Supporting open/closed communities to form and operate
+
+## Membership
+
+It is a requirement that an executive director and a member of the leadership team are members of the service team to ensure the team continues to have sufficient authority to make necessary decisions.
+
+We will run an open recruitment process for other membership places of no less than two places being available per quarter to anyone at Made Tech.
+
+## Meetings
+
+The service team shall meet with all available members on a weekly basis to review goals, committed actions and issues. The meeting is 45 minutes and is run by the team’s directly responsible individual or a nominated other.
+
+The service team is also responsible for ensuring the diversity and inclusion community  meets on a regular basis.
+
+## Managing issues
+
+The service team shall be available for issues to be raised via members of the diversity and inclusion community, open/closed communities or any other individual at Made Tech. Details on who to raise issues to should be documented in the [#supply-diversity-and-inclusion](https://madetechteam.slack.com/archives/CRAJF24CR) Slack channel.
+
+We have documented general guidance on [raising an issue](guides/welfare/raising_an_issue.md) elsewhere in the Handbook.

--- a/guides/equality-diversity-and-inclusion/about-service-team.md
+++ b/guides/equality-diversity-and-inclusion/about-service-team.md
@@ -31,4 +31,4 @@ The service team is also responsible for ensuring the diversity and inclusion co
 
 The service team shall be available for issues to be raised via members of the diversity and inclusion community, open/closed communities or any other individual at Made Tech. Details on who to raise issues to should be documented in the [#supply-diversity-and-inclusion](https://madetechteam.slack.com/archives/CRAJF24CR) Slack channel.
 
-We have documented general guidance on [raising an issue](guides/welfare/raising_an_issue.md) elsewhere in the Handbook.
+We have documented general guidance on [raising an issue](../welfare/raising_an_issue.md) elsewhere in the Handbook.


### PR DESCRIPTION
## What

- Add information about the ways in whichh we support ED&I with our service team, community meetup and open/closed communities
- Detail responsibilities of D&I service team
- Describe membership requirements, meeting frequency and on managing D&I related issues
- Add link from D&I README to about-service-team.md

## Why

It's important to document and sign post what we do so that we can be transparent in our processes/investments and the wider organisation knows how to get involved. 

Regarding specific information on the service team: it's important that this service areas responsibilities are understood by the wider organisation so that the group can be held accountable and be a go to place for raising issues and offering support.

We will add further content on the community meetup as well as on open/closed communities in the future.

## Thanks

Thanks for early reviews from @yaseminercan, @AlexHerbertMadeTech and Theone Johnson.