### PR TITLE
Add more D&I information

### DIFF
--- a/guides/equality-diversity-and-inclusion/README.md
+++ b/guides/equality-diversity-and-inclusion/README.md
@@ -14,6 +14,6 @@ We have a number of ways we support equality, diversity and inclusion at Made Te
 
 We have a [diversity and inclusion service team](about-service-team.md) who are responsible for defining our strategy, setting KPIs and objectives, supporting the wider organisation to take action to deliver on these objectives, and reporting on progress to our leadership team and the wider company. This team is an escalation point for D&I related issues and manages the operation of equality data collection and reporting. 
 
-We have a regular forum, our diversity and inclusion community meetup for discussing diversity and inclusion matters, scrutinising decisions being made by the diversity and inclusion service team, and making suggestions for future strategy.
+We have a regular forum, our [diversity and inclusion community meetup](about-di-community.md) for discussing diversity and inclusion matters, scrutinising decisions being made by the diversity and inclusion service team, and making suggestions for future strategy.
 
-We support open and closed community groups that meet to share experiences, raise issues and promote various aspects of diversity and inclusion. Open communities are free for anyone to join while closed communities are available to join by invite if you identify as belonging to that community.
+We support [open and closed community groups](about-open-and-closed-community.md) that meet to share experiences, raise issues and promote various aspects of diversity and inclusion. Open communities are free for anyone to join while closed communities are available to join by invite if you identify as belonging to that community.

--- a/guides/equality-diversity-and-inclusion/about-di-community.md
+++ b/guides/equality-diversity-and-inclusion/about-di-community.md
@@ -14,7 +14,7 @@ In particular it was set up to:
 
 ## When and how does the community meet?
 
-The community meets on a fortnightly basis via Google Meet. It is facilitated by a representative from the diversity and inclusion service team or another nominated individual. The format uses the [Lean Coffee](https://leancoffee.org/) approach where topics can be suggested, prioritised by voting and then discussed in order. The invite is open on Google Calendar so you may add yourself to be reminded, [ask on Slack](https://madetechteam.slack.com/archives/CRAJF24CR) for more information.
+The community meets on a fortnightly basis via Google Meet. It is facilitated by a representative from the [diversity and inclusion service team](./about-service-team.md) or another nominated individual. The format uses the [Lean Coffee](https://leancoffee.org/) approach where topics can be suggested, prioritised by voting and then discussed in order. The invite is open on Google Calendar so you may add yourself to be reminded, [ask on Slack](https://madetechteam.slack.com/archives/CRAJF24CR) for more information.
 
 From time-to-time the diversity and inclusion service team may change the format as it sees fit to deliver on its goals and objectives.
 
@@ -24,15 +24,15 @@ Minutes are added to the [inclusion repository](https://github.com/madetech/incl
 
 ## How else can I get involved?
 
-The community also hangs out on [Slack](https://madetechteam.slack.com/archives/CRAJF24CR). You may also consider joining one or more open or closed community groups.
+The community also hangs out on [Slack](https://madetechteam.slack.com/archives/CRAJF24CR). You may also consider joining one or more [open or closed community groups](about-open-and-closed-community.md).
 
 ## Who can join?
 
-Anyone can join the community meet up and Slack channel. It is attended by all available members of the diversity and inclusion service team and anyone else who wants to join in or just watch. It’s totally fine to join for part of the meet up and to keep your camera off if you prefer.
+Anyone can join the community meet up and Slack channel. It is attended by all available members of the [diversity and inclusion service team](./about-service-team.md) and anyone else who wants to join in or just watch. It’s totally fine to join for part of the meet up and to keep your camera off if you prefer.
 
 ## How do I raise an issue?
  
-Issues can be raised using the Lean Coffee format ahead of and during community meetings. This can be useful for organisational-wide issues but if the issue is about someone’s personal experience  it may be best to talk to a member of the service team first.
+Issues can be raised using the Lean Coffee format ahead of and during community meetings. This can be useful for organisational-wide issues but if the issue is about someone’s personal experience  it may be best to talk to a member of the [diversity and inclusion service team](./about-service-team.md) first.
 
 Anyone can contact the service team about an issue, or you could choose to raise it through a member of the diversity and inclusion community, or your diversity community group. Details on who to raise issues to are documented in the [#supply-diversity-and-inclusion Slack channel](https://madetechteam.slack.com/archives/CRAJF24CR).
 

--- a/guides/equality-diversity-and-inclusion/about-di-community.md
+++ b/guides/equality-diversity-and-inclusion/about-di-community.md
@@ -1,0 +1,39 @@
+# Diversity and inclusion community
+
+The diversity and inclusion community is an opportunity for anyone at Made Tech to join the conversation on how we progress and promote diversity and inclusion across the business.
+
+In particular it was set up to:
+
+- Be open to anyone
+- Meet on a regular basis
+- Discuss ideas and issues
+- Contribute to and review the strategy and plans of the [diversity and inclusion service team](./about-service-team.md)
+- Hold the diversity and inclusion service team to account for delivering on their plan
+- Review content changes before they are opened for wider review in the Handbook
+- Escalate issues
+
+## When and how does the community meet?
+
+The community meets on a fortnightly basis via Google Meet. It is facilitated by a representative from the diversity and inclusion service team or another nominated individual. The format uses the [Lean Coffee](https://leancoffee.org/) approach where topics can be suggested, prioritised by voting and then discussed in order. The invite is open on Google Calendar so you may add yourself to be reminded, [ask on Slack](https://madetechteam.slack.com/archives/CRAJF24CR) for more information.
+
+From time-to-time the diversity and inclusion service team may change the format as it sees fit to deliver on its goals and objectives.
+
+## Can I see what is discussed without joining?
+
+Minutes are added to the [inclusion repository](https://github.com/madetech/inclusion) for all meetings from the community.
+
+## How else can I get involved?
+
+The community also hangs out on [Slack](https://madetechteam.slack.com/archives/CRAJF24CR). You may also consider joining one or more open or closed community groups.
+
+## Who can join?
+
+Anyone can join the community meet up and Slack channel. It is attended by all available members of the diversity and inclusion service team and anyone else who wants to join in or just watch. It’s totally fine to join for part of the meet up and to keep your camera off if you prefer.
+
+## How do I raise an issue?
+ 
+Issues can be raised using the Lean Coffee format ahead of and during community meetings. This can be useful for organisational-wide issues but if the issue is about someone’s personal experience  it may be best to talk to a member of the service team first.
+
+Anyone can contact the service team about an issue, or you could choose to raise it through a member of the diversity and inclusion community, or your diversity community group. Details on who to raise issues to are documented in the [#supply-diversity-and-inclusion Slack channel](https://madetechteam.slack.com/archives/CRAJF24CR).
+
+We have documented general guidance on [raising an issue](https://github.com/madetech/handbook/blob/main/guides/welfare/raising_an_issue.md) elsewhere in the Handbook, or you can get in touch with the People team if you’re not sure who the best person is to speak to.

--- a/guides/equality-diversity-and-inclusion/about-open-and-closed-community.md
+++ b/guides/equality-diversity-and-inclusion/about-open-and-closed-community.md
@@ -1,0 +1,45 @@
+# Open and closed communities
+
+Open and closed community groups are collectives of individuals who come together to discuss particular challenges, ideas and experiences with regards to a particular community. These groups are self-organised, and will have their own ways of communicating and scheduling events.
+
+**An open community group** has open membership meaning anyone can join the group’s Slack channel, events and meetings.
+
+**A closed community group** is open only to those who are members of those communities. For example, to join the “women in tech” closed community group you would need to identify as a woman in order to have your request for an invite to be accepted. To join you will need to reach out to an organising member to request an invite. 
+
+You can find a list of open and closed communities in the description of the [diversity and inclusion Slack channel](https://madetechteam.slack.com/archives/CRAJF24CR). We share this list during onboarding weeks too.
+
+## Starting a group
+
+Anyone can start an open or closed community group as long as they comply with our [Equality, Diversity & Inclusion Policy](policy.md). To start one you should:
+
+- Create an open or closed or both Slack channel for your group
+- Notify the [diversity and inclusion service team](about-service-team.md) so they can add your group to the lists we share in Slack and during onboarding
+- Document either in Slack or a shareable file the purpose of your group and details on how and when you meet
+- If a closed group, provide details to the diversity and inclusion team on how someone can ask for an invite and what criteria they need to meet
+
+## Managing a group
+
+Open and closed community groups are self-organising and therefore need active management by its members to keep going. Civil servants have published a [“community development handbook”](https://www.gov.uk/government/publications/community-development-handbook/community-development-handbook) that provides lots of guidance on how to sustain a community.
+
+**Please note:** maintaining community groups is mentally and physically tiring – to keep the community sustainable this burden should not just fall on one or two individuals.
+
+## Support and budgets available
+
+There are a variety of ways we support open and closed communities to self-organise:
+
+- The culture and happiness team have budgets available for socials for your group and can provide support in organising events you may want to hold
+- We have diversity and inclusion and culture and happiness budget available for paying speakers to talk at open or closed events
+- We are organising a social and awareness calendar for key events that are relevant for our various community groups – this calendar enables our marketing team, employer branding and culture and happiness teams to organise and promote awareness
+- Our offices can be used for meetings and our existing communication platforms (Slack, Google Meet) can be used to virtual meet
+
+Ask on Slack if you want to take advantage of this support. If something is not listed here, please speak to the [diversity and inclusion service team](about-service-team.md) who will be happy to find an answer as to whether we can support your request.
+
+## Issue escalation
+
+Community groups form around particular identities, needs and/or experiences. If issues are discussed by these groups, they can be raised with the diversity and inclusion service team to be reviewed and supported. 
+
+If an individual has reported an issue to a group, it may be too much of a burden on that individual to escalate the issue themselves. In this case, a nominated individual from the group should be nominated to raise the issue on the affected individuals behalf.
+
+Details on who to raise issues to are documented in the [#supply-diversity-and-inclusion Slack channel](https://madetechteam.slack.com/archives/CRAJF24CR).
+
+We have documented general guidance on [raising an issue](https://github.com/madetech/handbook/blob/main/guides/welfare/raising_an_issue.md) elsewhere in the Handbook, or you can get in touch with the People team if you’re not sure who the best person is to speak to.

--- a/guides/equality-diversity-and-inclusion/about-service-team.md
+++ b/guides/equality-diversity-and-inclusion/about-service-team.md
@@ -12,8 +12,8 @@ Specifically, the diversity and inclusion service team is funded to and is respo
 - Being an escalation point with the ability to raise issues at an executive and board-level
 - Manage operation of equality data collection
 - Reporting on equality data to drive future decisions and investments
-- Running the diversity and inclusion community
-- Supporting open/closed communities to form and operate
+- Running the [diversity and inclusion community](about-di-community.md)
+- Supporting [open and closed communities](about-open-and-closed-community.md) to form and operate
 
 ## Membership
 


### PR DESCRIPTION
## What

- Add guidance on what the purpose of the D&I community is, how it is organised and run, and how to get involved
- Explain the purpose of open and closed communities, how to start one, how to get involved with existing ones and how they are run
- Add various links between diversity and inclusion content

## Why

Continuing on from #512, we add further information on the support structures we have created to ensure we continually invest in diversity and inclusion, to enable communities to form around identities/experiences/issues/ideas, to have a variety of routes that issues and ideas can be shared, to provide additional escalation routes where support is needed, and to ensure we make good progress on our commitments.