### PR TITLE
D&I minutes update

### DIFF
--- a/guides/equality-diversity-and-inclusion/about-di-community.md
+++ b/guides/equality-diversity-and-inclusion/about-di-community.md
@@ -20,7 +20,8 @@ From time-to-time the diversity and inclusion service team may change the format
 
 ## Can I see what is discussed without joining?
 
-Minutes are added to the [inclusion repository](https://github.com/madetech/inclusion) for all meetings from the community.
+Minutes are added to the [inclusion repository](https://github.com/madetech/inclusion) for all meetings from the community up to 27/10/2021.
+More recent minutes are available in this [Google Doc](https://docs.google.com/document/d/1JtDxGlA2v1uX2dycJQKZ_8Ff41t8jeriWqzFkGPQI7w/view)
 
 ## How else can I get involved?
 

--- a/guides/equality-diversity-and-inclusion/about-service-team.md
+++ b/guides/equality-diversity-and-inclusion/about-service-team.md
@@ -27,6 +27,10 @@ The service team shall meet with all available members on a weekly basis to revi
 
 The service team is also responsible for ensuring the diversity and inclusion community  meets on a regular basis.
 
+Minutes for these meetings are publically available.
+Historical records (03/09/2021 - 29/10/2021) are available on [GitHub](https://github.com/madetech/inclusion/tree/master/minutes/SA-weekly)
+More recent minutes (05/11/2021 onwards) are available in a [Google Doc](https://docs.google.com/document/d/1KlCwH72h7zqmbRFugwTzbcn_fawofRysWyi6qZRaZXg/view)
+
 ## Managing issues
 
 The service team shall be available for issues to be raised via members of the diversity and inclusion community, open/closed communities or any other individual at Made Tech. Details on who to raise issues to should be documented in the [#supply-diversity-and-inclusion](https://madetechteam.slack.com/archives/CRAJF24CR) Slack channel.


### PR DESCRIPTION
Following a discussion about people being hampered in editing the D&I meeting minutes via GitHub, it was agreed that going forwards, we would move these notes into a publically viewable Google Doc to improve the accessibility of the minutes.