### PR TITLE
Updated booking holiday over Christmas

### DIFF
--- a/benefits/flexible_holiday.md
+++ b/benefits/flexible_holiday.md
@@ -46,4 +46,4 @@ We want to ensure teams own their holidays and that includes thinking about the 
 
 ## Christmas at Made Tech 
 * Made Tech closes from Christmas Eve until the first working day back in January
-* You will not need to book this time off
+* You will need to book this time off as holiday in CharlieHR unless you were working


### PR DESCRIPTION
This PR is to reflect what to do in regards to booking leave over the Christmas period whilst the office is shut.