### PR TITLE
Design role content check

### DIFF
--- a/roles/designer.md
+++ b/roles/designer.md
@@ -1,10 +1,10 @@
 # Designer 
 
-- SFIA: [Level 3](sfia/designer.md)
 - Salary outside London: £36,000 - £45,000 
 - Salary inside London: £40,000 - £50,000
 - Location: Birmingham, Bristol, Glasgow, London, Manchester or Newcastle
 - Hybrid working: Client-site/office 1-2 days per week
+- SFIA: [Level 3](sfia/designer.md)
 
 Designers might already be a product designer, UX designer, service designer or interaction designer. 
 

--- a/roles/designer.md
+++ b/roles/designer.md
@@ -1,10 +1,12 @@
 # Designer 
 
-- [SFIA: Level 3](https://github.com/madetech/handbook/blob/main/roles/sfia/designer.md)
+- SFIA: [Level 3](sfia/designer.md)
 - Salary outside London: £36,000 - £45,000 
 - Salary inside London: £40,000 - £50,000
+- Location: Birmingham, Bristol, Glasgow, London, Manchester or Newcastle
+- Hybrid working: Client-site/office 1-2 days per week
 
-Designers might aleady be a product designer, UX designer, service designer or interaction designer. 
+Designers might already be a product designer, UX designer, service designer or interaction designer. 
 
 ## Summary
 
@@ -36,4 +38,15 @@ Designers are experienced practitioners who collaborate with others to tackle ch
 - Experienced in their Profession
 - Facilitation
 - Thinking through Making
+
+## Benefits
+
+Here are some of our most popular benefits listed below:
+
+- [Flexible Holiday](../benefits/flexible_holiday.md)
+- [Flexible Working Hours](../benefits/working_hours.md)
+- [Flexible Parental Leave](../guides/welfare/parental_leave.md)
+- [Remote Working](../benefits/remote_working.md)
+- [Paid counselling](../guides/welfare/paid_counselling.md)
+- [Paid anniversary break](../benefits/paid_anniversary_break.md)
 

--- a/roles/designer.md
+++ b/roles/designer.md
@@ -16,7 +16,7 @@ Designers are experienced practitioners who collaborate with others to tackle ch
 
 ## Key responsibilities 
 
-- Responsible to the Lead Designer for successfully designing and delivering of good public services
+- Responsible to the Senior Designer for successfully designing and delivering good public services
 - Turn team conversations and research into drawings and prototypes to create a shared understanding of problems to solve and ideas to test
 - Make things real by caring about content and design enough to ensure everyone can use public services
 - Make public services simple to explain and understand by removing complexity and keeping designs focused on creating outcomes for people and society

--- a/roles/designer.md
+++ b/roles/designer.md
@@ -21,7 +21,7 @@ Designers are experienced practitioners who collaborate with others to tackle ch
 - Make things real by caring about content and design enough to ensure everyone can use public services
 - Make public services simple to explain and understand by removing complexity and keeping designs focused on creating outcomes for people and society
 - Assure the quality of design delivery within their team 
-- Show teams by doing good habits for sharing and improving design work
+- Introduce good habits for sharing and improving design work into teams
 - Take part occasionally in the hiring of designers and researchers
 - Help define Made Tech design principles through delivering good public services
 - Contribute to a design studio culture at Made Tech and client offices

--- a/roles/designer.md
+++ b/roles/designer.md
@@ -10,18 +10,18 @@ Designers might already be a product designer, UX designer, service designer or 
 
 ## Summary
 
-Made Tech wants to positively impact the future of the country by using technology to improve society. We believe being design-led can create positive outcomes in the public sector, through critical services enabled by technology. We are building a community of designers and researchers to support the public sector growing demand for a design-led approach to service delivery. 
+Made Tech wants to positively impact the country's future by using technology to improve society. We believe being design-led can create positive outcomes in the public sector through critical services enabled by technology. We are building a community of designers and researchers to support the public sector growing demand for a design-led approach to service delivery.
 
-Designers are experienced practitioners who collaborate with others to tackle challenges faced by people and society. They work within a team to design and deliver public services. They do this by influencing the direction, assuring the quality of design delivery within their team, and by leading the end-to-end design of a chosen service. They are active members of a healthy User-Centred Design (UCD) community and culture at Made Tech. 
+Designers are experienced practitioners who collaborate with others to tackle challenges faced by people and society. They work within a team to design and deliver public services. They do this by influencing the direction, assuring the quality of design delivery within their team and by leading the end-to-end design of a chosen service. They are active members of a healthy User-Centred Design (UCD) community and culture at Made Tech. 
 
 ## Key responsibilities 
 
-- Responsible to the Lead Designer for success of designing and delivering good public services
-- Turn team conversations and research into drawings and prototypes, to create a shared understanding of problems to solve and ideas to test
-- Make things real, by caring about content and design enough to ensure everyone can use public services
-- Make public services simple to explain and understand, by removing complexity and keeping designs focused on creating outcomes for people and society
+- Responsible to the Lead Designer for successfully designing and delivering of good public services
+- Turn team conversations and research into drawings and prototypes to create a shared understanding of problems to solve and ideas to test
+- Make things real by caring about content and design enough to ensure everyone can use public services
+- Make public services simple to explain and understand by removing complexity and keeping designs focused on creating outcomes for people and society
 - Assure the quality of design delivery within their team 
-- Show teams by doing, good habits for sharing and improving design work
+- Show teams by doing good habits for sharing and improving design work
 - Take part occasionally in the hiring of designers and researchers
 - Help define Made Tech design principles through delivering good public services
 - Contribute to a design studio culture at Made Tech and client offices
@@ -49,4 +49,3 @@ Here are some of our most popular benefits listed below:
 - [Remote Working](../benefits/remote_working.md)
 - [Paid counselling](../guides/welfare/paid_counselling.md)
 - [Paid anniversary break](../benefits/paid_anniversary_break.md)
-

--- a/roles/lead_content_designer.md
+++ b/roles/lead_content_designer.md
@@ -4,13 +4,13 @@
 - Salary inside London: £60,000-£70,000 
 - Location: Birmingham, Bristol, Glasgow, London, Manchester or Newcastle
 - Hybrid working: Client-site/office 1-2 days per week
-- SFIA: [Level 5](https://sfia-online.org/en/sfia-7/responsibilities/level-5)
+- SFIA: [Level 5](sfia/lead_content_designer.md)
 
 ## Summary
 
-Made Tech wants to positively impact the future of the country by using technology to improve society. We believe being design-led can create positive outcomes in the public sector, through critical services enabled by technology. We are building a community of designers and researchers to support the public sector growing demand for a design-led approach to service delivery.
+Made Tech wants to positively impact the future of the country by using technology to improve society. We believe being design-led can create positive outcomes in the public sector through critical services enabled by technology. We are building a community of designers and researchers to support the public sector growing demand for a design-led approach to service delivery.
 
-Lead Content Designers are expert practitioners who influence and mentor others. They work with teams and clients to design and deliver public services. They do this by setting the direction, assuring the quality of content delivery across teams, and by leading multiple, or highly complex, services. They have an important role in creating a healthy User-Centred design (UCD) community and culture at Made Tech. 
+Lead Content Designers are expert practitioners who influence and mentor others. They work with teams and clients to design and deliver public services. They do this by setting the direction, assuring the quality of content delivery across teams, and leading multiple or highly complex services. They have an essential role in creating a healthy User-Centred design (UCD) community and culture at Made Tech. 
 
 ## Key responsibilities 
 

--- a/roles/lead_designer.md
+++ b/roles/lead_designer.md
@@ -10,20 +10,20 @@ Designers might already be a product designer, UX designer, service designer or 
 
 ## Summary
 
-Made Tech wants to positively impact the future of the country by using technology to improve society. We believe being design-led can create positive outcomes in the public sector, through critical services enabled by technology. We are building a community of designers and researchers to support the public sector growing demand for a design-led approach to service delivery.
+Made Tech wants to positively impact the country's future by using technology to improve society. We believe being design-led can create positive outcomes in the public sector through critical services enabled by technology. We are building a community of designers and researchers to support the public sector growing demand for a design-led approach to service delivery.
 
 Lead Designers are expert practitioners who influence and mentor others. They work with teams and clients to design and deliver public services. They do this by setting the direction, assuring the quality of design delivery across teams, and by leading multiple, or highly complex, services. They have an important role in creating a healthy User-Centred design (UCD) community and culture at Made Tech. 
 
 ## Key responsibilities 
 
-- Responsible to the Head of User-Centred Design for success of designing and delivering good public services
-- Turn team conversations and research into drawings and prototypes, to create a shared understanding of problems to solve and ideas to test
-- Make things real, by caring about content and interaction design enough to ensure everyone can use public services
-- Make public services simple to explain and understand, by removing complexity and keeping designs focused on creating outcomes for people and society
+- Responsible to the Head of User-Centred Design for successfully designing and delivering of good public services
+- Turn team conversations and research into drawings and prototypes to create a shared understanding of problems to solve and ideas to test
+- Make things real by caring about content and interaction design enough to ensure everyone can use public services
+- Make public services simple to explain and understand by removing complexity and keeping designs focused on creating outcomes for people and society
 - Assure the quality of design delivery across multiple teams 
-- Show teams by doing, good habits for sharing and improving design work
+- Show teams by doing good habits for sharing and improving design work
 - Build relationships with clients, earning their trust and understanding their needs
-- Support sales team to win new work and review bids relating to UCD
+- Support the sales team to win new work and review bids relating to UCD
 - Line management of designers
 - Support the hiring and onboarding of designers and researchers
 - Help define Made Tech design principles through delivering good public services
@@ -34,7 +34,7 @@ Lead Designers are expert practitioners who influence and mentor others. They wo
 
 - Delivery of good public services for users with clients
 - Case studies of how to design and deliver good public services and outcomes
-- Growth and happiness of UCD community at Made Tech
+- Growth and happiness of the UCD community at Made Tech
 
 ## Competencies 
 

--- a/roles/lead_designer.md
+++ b/roles/lead_designer.md
@@ -1,10 +1,12 @@
 # Lead Designer 
 
-- SFIA: [Level 5](sfia/lead_designer.md)
 - Salary outside London: £54,000 - £63,000
-- Salary inside London: £60,000-£70,000 
+- Salary inside London: £60,000-£70,000
+- Location: Birmingham, Bristol, Glasgow, London, Manchester or Newcastle
+- Hybrid working: Client-site/office 1-2 days per week
+- SFIA: [Level 5](sfia/lead_designer.md)
 
-Designers might aleady be a product designer, UX designer, service designer or interaction designer. 
+Designers might already be a product designer, UX designer, service designer or interaction designer.
 
 ## Summary
 
@@ -42,3 +44,14 @@ Lead Designers are expert practitioners who influence and mentor others. They wo
 - Experienced in their Profession
 - Facilitation
 - Thinking through Making
+
+## Benefits
+
+Here are some of our most popular benefits listed below:
+
+- [Flexible Holiday](../benefits/flexible_holiday.md)
+- [Flexible Working Hours](../benefits/working_hours.md)
+- [Flexible Parental Leave](../guides/welfare/parental_leave.md)
+- [Remote Working](../benefits/remote_working.md)
+- [Paid counselling](../guides/welfare/paid_counselling.md)
+- [Paid anniversary break](../benefits/paid_anniversary_break.md)

--- a/roles/lead_designer.md
+++ b/roles/lead_designer.md
@@ -21,7 +21,7 @@ Lead Designers are expert practitioners who influence and mentor others. They wo
 - Make things real by caring about content and interaction design enough to ensure everyone can use public services
 - Make public services simple to explain and understand by removing complexity and keeping designs focused on creating outcomes for people and society
 - Assure the quality of design delivery across multiple teams 
-- Show teams by doing good habits for sharing and improving design work
+- Introduce good habits for sharing and improving design work into teams
 - Build relationships with clients, earning their trust and understanding their needs
 - Support the sales team to win new work and review bids relating to UCD
 - Line management of designers

--- a/roles/lead_designer.md
+++ b/roles/lead_designer.md
@@ -16,7 +16,7 @@ Lead Designers are expert practitioners who influence and mentor others. They wo
 
 ## Key responsibilities 
 
-- Responsible to the Head of User-Centred Design for successfully designing and delivering of good public services
+- Responsible to the UCD Principal for successfully designing and delivering good public services
 - Turn team conversations and research into drawings and prototypes to create a shared understanding of problems to solve and ideas to test
 - Make things real by caring about content and interaction design enough to ensure everyone can use public services
 - Make public services simple to explain and understand by removing complexity and keeping designs focused on creating outcomes for people and society

--- a/roles/lead_user_researcher.md
+++ b/roles/lead_user_researcher.md
@@ -1,8 +1,10 @@
 # Lead User Researcher
 
-- SFIA: [Level 5](https://sfia-online.org/en/sfia-7/responsibilities/level-5)
 - Salary outside London: £54,000 - £63,000
 - Salary inside London: £60,000-£70,000 
+- Location: Birmingham, Bristol, Glasgow, London, Manchester or Newcastle
+- Hybrid working: Client-site/office 1-2 days per week
+- SFIA: [Level 5](https://sfia-online.org/en/sfia-7/responsibilities/level-5)
 
 ## Summary
 
@@ -43,7 +45,13 @@ Lead User Researchers are expert practitioners who influence and mentor others. 
 - Experienced in their Profession
 - Facilitation
 
-## Salary
+## Benefits
 
-This role has a salary of £60,000-£70,000 per annum depending on experience. 
+Here are some of our most popular benefits listed below:
 
+- [Flexible Holiday](../benefits/flexible_holiday.md)
+- [Flexible Working Hours](../benefits/working_hours.md)
+- [Flexible Parental Leave](../guides/welfare/parental_leave.md)
+- [Remote Working](../benefits/remote_working.md)
+- [Paid counselling](../guides/welfare/paid_counselling.md)
+- [Paid anniversary break](../benefits/paid_anniversary_break.md)

--- a/roles/lead_user_researcher.md
+++ b/roles/lead_user_researcher.md
@@ -4,7 +4,7 @@
 - Salary inside London: £60,000-£70,000 
 - Location: Birmingham, Bristol, Glasgow, London, Manchester or Newcastle
 - Hybrid working: Client-site/office 1-2 days per week
-- SFIA: [Level 5](/sfia/lead_user_researcher.md)
+- SFIA: [Level 5](sfia/lead_user_researcher.md)
 
 ## Summary
 

--- a/roles/senior_content_designer.md
+++ b/roles/senior_content_designer.md
@@ -4,7 +4,7 @@
 - Salary inside London: £50,000-£60,000
 - Location: Birmingham, Bristol, Glasgow, London, Manchester or Newcastle
 - Hybrid working: Client-site/office 1-2 days per week
-- SFIA: [Level 4](https://sfia-online.org/en/sfia-7/responsibilities/level-4)
+- SFIA: [Level 4](sfia/senior_content_designer.md)
 
 ## Summary
 

--- a/roles/senior_content_designer.md
+++ b/roles/senior_content_designer.md
@@ -14,7 +14,7 @@ Our Senior Content Designer are strong practitioners who work with minimal suppo
 
 ## Key responsibilities 
 
-- Responsible to the UCD Principal for success of designing and delivering good public services
+- Responsible to the Lead Content Designer for successfully designing and delivering good public services
 - Turn team conversations and research into user-centred content to create a shared understanding of problems to solve and ideas to test
 - Make things real, by caring about content enough to ensure everyone can use public services
 - Make public services simple to explain and understand, by removing complexity and keeping designs focused on creating outcomes for people and society

--- a/roles/senior_designer.md
+++ b/roles/senior_designer.md
@@ -10,7 +10,7 @@ Designers might already be a product designer, UX designer, service designer or 
 
 ## Summary
 
-Made Tech wants to positively impact country's future by using technology to improve society. We believe being design-led can create positive outcomes in the public sector through critical services enabled by technology. We are building a community of designers and researchers to support the public sector growing demand for a design-led approach to service delivery.
+Made Tech wants to positively impact the country's future by using technology to improve society. We believe being design-led can create positive outcomes in the public sector through critical services enabled by technology. We are building a community of designers and researchers to support the public sector growing demand for a design-led approach to service delivery.
 
 Our Senior Designers are strong practitioners who work with minimal support and can influence and mentor others to design and deliver public services. They do this by setting the direction and assuring the quality of design delivery within a team working on complicated and large scale service. They are vocal and visible contributors to a healthy user-centred design (UCD) community and culture at Made Tech.
 

--- a/roles/senior_designer.md
+++ b/roles/senior_designer.md
@@ -1,16 +1,18 @@
 # Senior Designer 
 
-- SFIA: [Level 4](sfia/senior_designer.md)
 - Salary outside London: £44,000 - £53,000
 - Salary inside London: £50,000-£60,000
+- Location: Birmingham, Bristol, Glasgow, London, Manchester or Newcastle
+- Hybrid working: Client-site/office 1-2 days per week
+- SFIA: [Level 4](sfia/senior_designer.md)
 
-Designers might aleady be a product designer, UX designer, service designer or interaction designer. 
+Designers might already be a product designer, UX designer, service designer or interaction designer. 
 
 ## Summary
 
 Made Tech wants to positively impact the future of the country by using technology to improve society. We believe being design-led can create positive outcomes in the public sector, through critical services enabled by technology. We are building a community of designers and researchers to support the public sector growing demand for a design-led approach to service delivery.
 
-Our Senior Designer are strong practitioners who works with minimal support and can influence and mentor others to design and deliver public services. They do this by setting the direction, assuring the quality of design delivery within a team workong a complicated and large scale service. They are vocal and visible contributors to a healthy user-centred design (UCD) community and culture at Made Tech.
+Our Senior Designer are strong practitioners who work with minimal support and can influence and mentor others to design and deliver public services. They do this by setting the direction, assuring the quality of design delivery within a team working on a complicated and large scale service. They are vocal and visible contributors to a healthy user-centred design (UCD) community and culture at Made Tech.
 
 ## Key responsibilities 
 
@@ -41,7 +43,15 @@ Our Senior Designer are strong practitioners who works with minimal support and 
 - Facilitation
 - Thinking through Making
 
-## Salary
+## Benefits
 
-This role has a salary of £60,000-£70,000 per annum depending on experience. 
+Here are some of our most popular benefits listed below:
+
+- [Flexible Holiday](../benefits/flexible_holiday.md)
+- [Flexible Working Hours](../benefits/working_hours.md)
+- [Flexible Parental Leave](../guides/welfare/parental_leave.md)
+- [Remote Working](../benefits/remote_working.md)
+- [Paid counselling](../guides/welfare/paid_counselling.md)
+- [Paid anniversary break](../benefits/paid_anniversary_break.md)
+
 

--- a/roles/senior_designer.md
+++ b/roles/senior_designer.md
@@ -16,7 +16,7 @@ Our Senior Designers are strong practitioners who work with minimal support and 
 
 ## Key responsibilities 
 
-- Responsible to the Lead Designer for successfully designing and delivering of good public services
+- Responsible to the Lead Designer for successfully designing and delivering good public services
 - Turn team conversations and research into drawings and prototypes to create a shared understanding of problems to solve and ideas to test
 - Make things real by caring about content and interaction design enough to ensure everyone can use public services
 - Make public services simple to explain and understand by removing complexity and keeping designs focused on creating outcomes for people and society

--- a/roles/senior_designer.md
+++ b/roles/senior_designer.md
@@ -10,18 +10,18 @@ Designers might already be a product designer, UX designer, service designer or 
 
 ## Summary
 
-Made Tech wants to positively impact the future of the country by using technology to improve society. We believe being design-led can create positive outcomes in the public sector, through critical services enabled by technology. We are building a community of designers and researchers to support the public sector growing demand for a design-led approach to service delivery.
+Made Tech wants to positively impact country's future by using technology to improve society. We believe being design-led can create positive outcomes in the public sector through critical services enabled by technology. We are building a community of designers and researchers to support the public sector growing demand for a design-led approach to service delivery.
 
-Our Senior Designer are strong practitioners who work with minimal support and can influence and mentor others to design and deliver public services. They do this by setting the direction, assuring the quality of design delivery within a team working on a complicated and large scale service. They are vocal and visible contributors to a healthy user-centred design (UCD) community and culture at Made Tech.
+Our Senior Designers are strong practitioners who work with minimal support and can influence and mentor others to design and deliver public services. They do this by setting the direction and assuring the quality of design delivery within a team working on complicated and large scale service. They are vocal and visible contributors to a healthy user-centred design (UCD) community and culture at Made Tech.
 
 ## Key responsibilities 
 
-- Responsible to the Lead Designer for success of designing and delivering good public services
-- Turn team conversations and research into drawings and prototypes, to create a shared understanding of problems to solve and ideas to test
-- Make things real, by caring about content and interaction design enough to ensure everyone can use public services
-- Make public services simple to explain and understand, by removing complexity and keeping designs focused on creating outcomes for people and society
+- Responsible to the Lead Designer for successfully designing and delivering of good public services
+- Turn team conversations and research into drawings and prototypes to create a shared understanding of problems to solve and ideas to test
+- Make things real by caring about content and interaction design enough to ensure everyone can use public services
+- Make public services simple to explain and understand by removing complexity and keeping designs focused on creating outcomes for people and society
 - Assure the quality of design delivery across multiple teams 
-- Show teams by doing, good habits for sharing and improving design work
+- Show teams by doing good habits for sharing and improving design work
 - Line management of designers
 - Support the hiring and onboarding of designers and researchers
 - Help define Made Tech design principles through delivering good public services
@@ -32,7 +32,7 @@ Our Senior Designer are strong practitioners who work with minimal support and c
 
 - Delivery of good public services for users with clients
 - Case studies of how to design and deliver good public services and outcomes
-- Growth and happiness of UCD community at Made Tech
+- Growth and happiness of the UCD community at Made Tech
 
 ## Competencies 
 

--- a/roles/senior_designer.md
+++ b/roles/senior_designer.md
@@ -21,7 +21,7 @@ Our Senior Designers are strong practitioners who work with minimal support and 
 - Make things real by caring about content and interaction design enough to ensure everyone can use public services
 - Make public services simple to explain and understand by removing complexity and keeping designs focused on creating outcomes for people and society
 - Assure the quality of design delivery across multiple teams 
-- Show teams by doing good habits for sharing and improving design work
+- Introduce good habits for sharing and improving design work into teams
 - Line management of designers
 - Support the hiring and onboarding of designers and researchers
 - Help define Made Tech design principles through delivering good public services

--- a/roles/senior_user_researcher.md
+++ b/roles/senior_user_researcher.md
@@ -4,7 +4,7 @@
 - Hybrid working: Client-site/office 1-2 days per week
 - Salary outside London: £44,000 - £53,000
 - Salary inside London: £50,000-£60,000 
-- SFIA: [Level 4](/sfia/senior_user_researcher.md)
+- SFIA: [Level 4](sfia/senior_user_researcher.md)
 
 
 ## Key responsibilities 

--- a/roles/ucd_principal.md
+++ b/roles/ucd_principal.md
@@ -47,9 +47,9 @@ As a User Centred Design Principal, reporting to the Head of Design, you’ll en
 
 - Working within an account or programme leadership team
 - Working with sales teams to win new work
-- Worked with multidisciplinary digital and technology teams
-- Worked within healthcare
-- Worked in the open - sharing, working little and often
+- Working with multidisciplinary digital and technology teams
+- Experience in healthcare
+- Working in the open - sharing little and often
 - Experience in re-designing legacy services
 - Maintain a deep working knowledge of design and research techniques
 

--- a/roles/user_researcher.md
+++ b/roles/user_researcher.md
@@ -20,7 +20,7 @@ User Researchers are experienced practitioners who collaborate with others to un
 - Analyse and interpret raw research into findings so that teams can confidently confirm or challenge their understandings of problems and ideas
 - Involve whole teams in user research to build their understanding and empathy for people using and running public services
 - Assure the quality of decisions within their team 
-- Show teams by doing good habits for sharing research and making decisions 
+- Introduce good habits for sharing and improving design work into teams 
 - Take part occasionally in the hiring of designers and researchers
 - Help define Made Tech design principles through delivering good public services
 - Contribute to a design studio culture at Made Tech and client offices

--- a/roles/user_researcher.md
+++ b/roles/user_researcher.md
@@ -4,7 +4,7 @@
 - Salary inside London: £40,000 - £50,000
 - Location: Birmingham, Bristol, Glasgow, London, Manchester or Newcastle
 - Hybrid working: Client-site/office 1-2 days per week
-- SFIA: [Level 3](https://sfia-online.org/en/sfia-7/responsibilities/level-3)
+- SFIA: [Level 3](sfia/user_researcher.md)
 
 ## Summary
 


### PR DESCRIPTION
Updated content for:

* UCD Principal
* Senior, Lead and Designer roles
* Senior, Lead and User Researcher roles
* Senior and Lead Content Designer roles

To:

* Fix consistency of basic role information, like the salary and working location
* Include competencies where they were missing
* Include benefits across all roles
* Fix some typos and grammatical bits 'n bobs

Particularly:

It's worth checking out the [changes I made to the UCD Principal role](https://github.com/madetech/handbook/pull/564/commits/61853780740cf1b517bdbda6674ae52995667f2d) to ensure that this is correct.