### PR TITLE
Update pairing.md

### DIFF
--- a/guides/hiring/pairing.md
+++ b/guides/hiring/pairing.md
@@ -51,7 +51,7 @@ Tell the candidate the key facts:
 - Ask if they’re familiar with pair programming. If not, explain briefly.
 - Decide on a pairing style together.
 - Ask if they’ve done a kata before. If not, explain briefly.
-- Ask which kata they’d like to do. If they’re not sure, suggest one from [this list](https://learn.madetech.com/katas/). Tennis or Bowling work well, and if the candidate is applying for a Senior or Lead Engineer role, then they must pick one of these two.
+- Ask which kata they’d like to do. If they’re not sure, suggest one from [this list](https://learn.madetech.com/katas/). Tennis or Bowling work well and, if the candidate is applying for a Senior or Lead Engineer role, then they must pick one of these two.
 - Ask if they’re familiar with test-driven development (TDD). If not, explain briefly.
 - Tell the candidate you’d like to write tests as part of doing the kata.
 - If you’re remote, decide how you’ll pair. You could use Tuple, Live Share, or screen sharing.


### PR DESCRIPTION
Modifying this guidance to require that Senior or Lead Engineer candidates choose one of Tennis or Bowling katas as the others may not have enough complexity to be able to assess the candidate at that level.