### PR TITLE
exclude *.github.com urls from markdown-link-check

### DIFF
--- a/build.js
+++ b/build.js
@@ -30,7 +30,7 @@ function checkFile (fileName) {
         { pattern: /moneysavingexpert.com/ },
         { pattern: /currys.co.uk/ },
         { pattern: /pcworld.co.uk/ },
-        { pattern: /\.github.com/ }              // github subsites are returning 403. markdown-link-check are looking at it.
+        { pattern: /\.github.com/ }              // github subsites are returning 403. markdown-link-check are looking at it. https://github.com/tcort/markdown-link-check/issues/201
       ]
 
       markdownLinkCheck(md, { baseUrl, ignorePatterns }, (err, results) => {

--- a/build.js
+++ b/build.js
@@ -30,7 +30,7 @@ function checkFile (fileName) {
         { pattern: /moneysavingexpert.com/ },
         { pattern: /currys.co.uk/ },
         { pattern: /pcworld.co.uk/ },
-        { pattern: /.github.com/ }              // github subsites are returning 403. markdown-link-check are looking at it.
+        { pattern: /\.github.com/ }              // github subsites are returning 403. markdown-link-check are looking at it.
       ]
 
       markdownLinkCheck(md, { baseUrl, ignorePatterns }, (err, results) => {

--- a/build.js
+++ b/build.js
@@ -27,9 +27,10 @@ function checkFile (fileName) {
         { pattern: /clamav.net/ },
         { pattern: /docs.google.com/ },        // Internal docs are hidden and will cause errors sometimes
         { pattern: /udemy.com/ },               // udemy returns 403 status to circle ci hosts
-	{ pattern: /moneysavingexpert.com/ },
-	{ pattern: /currys.co.uk/ },
-	{ pattern: /pcworld.co.uk/ }
+        { pattern: /moneysavingexpert.com/ },
+        { pattern: /currys.co.uk/ },
+        { pattern: /pcworld.co.uk/ },
+        { pattern: /.github.com/ }              // github subsites are returning 403. markdown-link-check are looking at it.
       ]
 
       markdownLinkCheck(md, { baseUrl, ignorePatterns }, (err, results) => {


### PR DESCRIPTION
Hopefully a temporary workaround. There's an [issue reported](https://github.com/tcort/markdown-link-check/issues/201) on the markdown-link-check library