### PR TITLE
Fixes: incorrect max level for leads to interview

### DIFF
--- a/roles/sfia/lead_software_engineer.md
+++ b/roles/sfia/lead_software_engineer.md
@@ -63,4 +63,4 @@ Below are examples of behaviours and responsibilities a person in this role migh
 - Can navigate complex stakeholder and organisational environments
 - Able to support and manage multiple workstreams, while delivering within one or more of those workstreams
 - Able to coordinate and manage supplier, partner and customer staff alongside Made Tech
-- Able to lead hiring interviews for Engineer 1 to Senior Engineer candidates
+- Able to lead hiring interviews for Engineer 1 to Lead Engineer candidates


### PR DESCRIPTION
Lead engineers can lead hiring interviews for leads.