### PR TITLE
Add cyber roles

### DIFF
--- a/roles/README.md
+++ b/roles/README.md
@@ -125,8 +125,8 @@ Leadership
 
 Security Engineering
  - Senior Security Engineer
- - Lead Security Engineer
- - Principal Security Engineer
+ - [Lead Security Engineer](lead_security_engineer.md)
+ - [Principal Security Engineer](principal_security_engineer.md)
 
 Leadership
 

--- a/roles/lead_security_engineer.md
+++ b/roles/lead_security_engineer.md
@@ -1,0 +1,86 @@
+# Lead Security Engineer
+
+UK-based in Birmingham, Bristol, Glasgow, Manchester, Newcastle, London & Swansea.
+
+Please apply for this role at [www.madetech.com/careers](https://www.madetech.com/careers).
+
+Our Lead Security Engineers enable public sector organisations to mitigate cyber and information security risks across an increasingly complex and threatened mix of technology-enabled services. They lead teams to make sure digital and data services are securely designed and built from the outset, and work with technology teams to make sure entire platforms are securely monitored with timely incident response.
+
+## What does the job entail?
+
+At Made Tech we want to positively impact the future of the country by using technology to improve society, for everyone. We want to empower the public sector to deliver and continuously improve digital services that are user-centric, data-driven and freed from legacy technology. Underpinning this is a need for us to do this securely, handling public data safely, and defending against increasing cyber and information security risks.
+
+As a Lead Security Engineer you will work closely with clients to help inform their security strategy and to ensure our teams are delivering secure digital services and cloud-based platforms, aligned to our customers risk tolerance. You will be expected to upskill clients and Made Tech delivery teams, including pair programming with other engineers.
+
+You will need to be comfortable sharing your knowledge and skills with others. We’d love to hear some examples of mentoring, coaching and growing team members. Maybe you will have written some blog posts about your discipline, or perhaps even delivered a talk or two.
+
+## What experience are we looking for?
+
+While we will look for you to have experience in these things, if you don’t have one of these don’t let that stop you from applying.
+
+- Working directly with customers
+- Leading cyber engineering workstreams and embedding into digital, data and technology teams to upskill them while managing risk and compliance
+- Shaping cyber and information security strategy and managing continuous risk reduction across multiple digital or data services and cloud-based platforms
+- End-to-end security involvement, including governance, risk and compliance, operational security, supply chain security and secure user management
+- Identifying security issues in existing system designs, digital services (products) and platforms, including recommending mitigations that balance cost, risk and usability
+- Strong understanding of integrating security as part of a multidisciplinary approach to delivering digital services (products) and platforms utilising a DevSecOps approach and enabling Continuous Security as part of wider CI/CD tools and practices
+- Up-to-date understanding of, and ensuring compliance to, security standards and regulations including GDS Technology Code of Practice, NCSC Cyber Principles, ISO27001, SoC, NIST, PCI, and GDPR
+- Up-to-date understanding of testing the security of software and infrastructure using appropriate security tools including automated cloud-based tooling
+- Up-to-date understanding of network security (e.g. OSI, TCP/IP), web application security (e.g. OWASP) and cryptographic controls (e.g. PKI, TLS)
+- Up-to-date understanding of identity management and authentication/authorisation products and patterns
+- Evidence of self-development – we value keen learners
+- Drive to deliver outcomes for users
+- Desire to mentor others
+- Empathy and people skills
+
+## Optional experience
+
+Don’t forget to mention any of the experiences listed below. While it’s optional, it’s all highly desired!
+
+- Experience in technology consultancy
+- Pair programming
+- A relevant cyber and information security qualification (one of: CISSP, SSCP, CISM, CRISC, CAP, CPP, GCHQ-certified Master’s degree in cyber security, or a PhD that is relevant to cyber security)
+- Penetration testing qualifications (one of: OSCP, CREST, TIGER or equivalent)
+- Working within bid teams to win contracts exceeding value of £1m
+- Working with multidisciplinary digital and technology teams
+- Working within the public sector
+- Experience in hiring, forming and running teams
+
+## What we will provide you
+
+Balancing life and work:
+
+* ✈️ [Flexible Holiday](../benefits/flexible_holiday.md) – We trust you to take as much holiday as you need
+* 🕰️ [Flexible Working Hours](../benefits/working_hours.md) – We are flexible with what hours you work
+* 🗓️ [Flexible Working Days](../benefits/flexible_working.md) – We are flexible to the amount of days you work in a week
+* 👶 [Flexible Parental Leave](../guides/welfare/parental_leave.md) – We provide flexible parental leave options
+* 👩‍💻 [Remote Working](../benefits/remote_working.md) – We offer part-time remote working for all our staff
+* 🤗 [Paid counselling](../guides/welfare/paid_counselling.md) – We offer paid counselling as well as financial and legal advice
+* 🏖️ [Paid anniversary break](../benefits/paid_anniversary_break.md) – We celebrate your 3 and 5 year anniversary with us by buying your family a holiday
+
+Making work as fabulous as possible:
+
+* 💻 [Work Ready](../benefits/work_ready.md) – We'll buy you a Macbook, ergonomic equipment, books, conferences, training, and more
+* 💡 [Learning](../guides/learning/README.md) – We offer 12 days per year of personal learning time and a £300 personal learning budget
+* 🍽️ [Friday Lunches](../benefits/friday_lunch.md) – We randomly match up 8 colleagues every Friday and pay for lunch
+* 🍻 [Friday Drinks](../benefits/friday_drinks.md) – We pay for social drinks on a Friday
+
+Compensating you fairly:
+
+* 💷 [Transparent Salary Bands](../roles/README.md) – We publish salary bands so you know you're being fairly compensated
+* 👌 [Annual Salary Reviews](../guides/compensation/salary_reviews.md) – We review your salary on an annual basis
+* ⛷️ [Pension Scheme](../benefits/pension_scheme.md) – We provide a pension scheme so you can save for your future and we'll contribute to it
+* 🚄 [Season Ticket Loan](../benefits/season_ticket_loan.md) – We provide loans to help you pay for your travel
+* 🚲 [Cycle To Work Scheme](../benefits/cycle_to_work_scheme.md) – We offer the cycle to work scheme to help pay for your bicycle
+* 🚕 [Expenses Paid](../guides/compensation/expenses.md) – Taxi to a meeting? Want to take a customer to lunch? Expenses are no hassle!
+
+## Salary
+
+The salary for this role is location dependant:
+
+- UK: £70,000 - £100,000
+- London & South East: £73,500 - £105,000
+
+## Applying
+
+Please apply for this role at [www.madetech.com/careers](https://www.madetech.com/careers). If you don't quite fit the role, the role doesn't quite fit you, or you have questions please email us at [careers@madetech.com](mailto:careers@madetech.com) where we will be happy to help.

--- a/roles/principal_security_engineer.md
+++ b/roles/principal_security_engineer.md
@@ -1,0 +1,92 @@
+# Principal Security Engineer
+
+UK-based in Birmingham, Bristol, Glasgow, Manchester, Newcastle, London & Swansea.
+
+Please apply for this role at [www.madetech.com/careers](https://www.madetech.com/careers).
+
+Our Principal Security Engineers enable public sector organisations to mitigate cyber and information security risks across an increasingly complex and threatened mix of technology-enabled services. They provide senior security leadership and support to our clients and teams, build and manage key relationships with clients, manage security and risk across one or more accounts, and support sales.
+
+## What does the job entail?
+
+At Made Tech we want to positively impact the future of the country by using technology to improve society, for everyone. We want to empower the public sector to deliver and continuously improve digital services that are user-centric, data-driven and freed from legacy technology. Underpinning this is a need for us to do this securely, handling public data safely, and defending against increasing cyber and information security risks.
+
+As a Principal Security Engineer you will work closely with our customers senior leadership to help inform their security strategy and to ensure our teams are delivering secure digital services and cloud-based platforms, aligned to our customers risk tolerance. Working alongside delivery, client and other capability principals, you will help shape account plans and be responsible for delivering against them.
+
+Working with Made Tech's leadership you will ensure our work with customers is aligned to our growth goals and you will play a pivotal role in identifying new opportunities and winning work. Running bid teams, supporting sales teams and developing new business is critical to this role.
+
+You will coach and support Lead Security Engineers to steer their team's towards success. You will also be responsible for hiring and line managing Lead Security Engineers.
+
+While this is not a hands-on coding technical role, the importance of credibility in internet-era approaches to digital, data and technology in the public sector cannot be understated. You will be expected to maintain a broad technical knowledge of modern cyber security practices, be able to shape security strategy and roadmaps, and hold others to account for technical quality.
+
+As a security leader within Made Tech you will be expected to maintain and grow your professional network. You will be expected to contribute to thought leadership, content and events and should have a proven track record of doing so.
+
+## What experience are we looking for?
+
+While we will look for you to have experience in these things, if you don’t have one of these don’t let that stop you from applying.
+
+- Working directly with customers
+- Working within a technology consultancy
+- Developing a cyber and information security capability or function
+- Shaping cyber and information security strategy and managing continuous risk reduction across an organisation, portfolio and/or multiple programmes
+- End-to-end security involvement, including governance, risk and compliance, operational security, supply chain security and secure user management
+- Identifying security issues in existing system designs, digital services (products) and platforms, including recommending mitigations that balance cost, risk and usability
+- Strong understanding of integrating security as part of a multidisciplinary approach to delivering digital services (products) and platforms utilising a DevSecOps approach and enabling Continuous Security as part of wider CI/CD tools and practices
+- Up-to-date understanding of, and ensuring compliance to, security standards and regulations including GDS Technology Code of Practice, NCSC Cyber Principles, ISO27001, SoC, NIST, PCI, and GDPR
+- Up-to-date understanding of testing the security of software and infrastructure using appropriate security tools including automated cloud-based tooling
+- Up-to-date understanding of network security (e.g. OSI, TCP/IP), web application security (e.g. OWASP) and cryptographic controls (e.g. PKI, TLS)
+- Up-to-date understanding of identity management and authentication/authorisation products and patterns
+- Evidence of self-development – we value keen learners
+- Drive to deliver outcomes for users
+- Desire to mentor others
+- Empathy and people skills
+
+## Optional experience
+
+Don’t forget to mention any of the experiences listed below. While it’s optional, it’s all highly desired!
+
+- Leadership of a cyber and information security capability or function
+- A relevant cyber and information security qualification (one of: CISSP, SSCP, CISM, CRISC, CAP, CPP, GCHQ-certified Master’s degree in cyber security, or a PhD that is relevant to cyber security)
+- Penetration testing qualifications (one of: OSCP, CREST, TIGER or equivalent)
+- Working within bid teams to win contracts exceeding value of £1m
+- Working with multidisciplinary digital and technology teams
+- Working within the public sector
+- Experience in hiring, forming and running teams
+
+## What we will provide you
+
+Balancing life and work:
+
+* ✈️ [Flexible Holiday](../benefits/flexible_holiday.md) – We trust you to take as much holiday as you need
+* 🕰️ [Flexible Working Hours](../benefits/working_hours.md) – We are flexible with what hours you work
+* 🗓️ [Flexible Working Days](../benefits/flexible_working.md) – We are flexible to the amount of days you work in a week
+* 👶 [Flexible Parental Leave](../guides/welfare/parental_leave.md) – We provide flexible parental leave options
+* 👩‍💻 [Remote Working](../benefits/remote_working.md) – We offer part-time remote working for all our staff
+* 🤗 [Paid counselling](../guides/welfare/paid_counselling.md) – We offer paid counselling as well as financial and legal advice
+* 🏖️ [Paid anniversary break](../benefits/paid_anniversary_break.md) – We celebrate your 3 and 5 year anniversary with us by buying your family a holiday
+
+Making work as fabulous as possible:
+
+* 💻 [Work Ready](../benefits/work_ready.md) – We'll buy you a Macbook, ergonomic equipment, books, conferences, training, and more
+* 💡 [Learning](../guides/learning/README.md) – We offer 12 days per year of personal learning time and a £300 personal learning budget
+* 🍽️ [Friday Lunches](../benefits/friday_lunch.md) – We randomly match up 8 colleagues every Friday and pay for lunch
+* 🍻 [Friday Drinks](../benefits/friday_drinks.md) – We pay for social drinks on a Friday
+
+Compensating you fairly:
+
+* 💷 [Transparent Salary Bands](../roles/README.md) – We publish salary bands so you know you're being fairly compensated
+* 👌 [Annual Salary Reviews](../guides/compensation/salary_reviews.md) – We review your salary on an annual basis
+* ⛷️ [Pension Scheme](../benefits/pension_scheme.md) – We provide a pension scheme so you can save for your future and we'll contribute to it
+* 🚄 [Season Ticket Loan](../benefits/season_ticket_loan.md) – We provide loans to help you pay for your travel
+* 🚲 [Cycle To Work Scheme](../benefits/cycle_to_work_scheme.md) – We offer the cycle to work scheme to help pay for your bicycle
+* 🚕 [Expenses Paid](../guides/compensation/expenses.md) – Taxi to a meeting? Want to take a customer to lunch? Expenses are no hassle!
+
+## Salary
+
+The salary for this role is location dependant:
+
+- UK: £85,000 - £135,000
+- London & South East: £89,250 - £141,750
+
+## Applying
+
+Please apply for this role at [www.madetech.com/careers](https://www.madetech.com/careers). If you don't quite fit the role, the role doesn't quite fit you, or you have questions please email us at [careers@madetech.com](mailto:careers@madetech.com) where we will be happy to help.


### PR DESCRIPTION
# What

- [Add Principal Security Engineer role](https://github.com/madetech/handbook/commit/649a19ad50f831d9ad81ad41f9b91e2e7936dcbb)
- [Add Lead Security Engineer role](https://github.com/madetech/handbook/commit/14e15d5a3850a6d73a157d6b902df7197f88fcf2)
- [Add links to Lead and Principal Security Engineers from role overview](https://github.com/madetech/handbook/commit/e23a0bff04b6b772c91a771c9ca927155f4b9db8)

# Why

We are in the process of making sure we have 100% coverage of delivery and capability roles in the Handbook. Look out for more PRs this week!