### PR TITLE
Add Head of Delivery Management role

### DIFF
--- a/roles/README.md
+++ b/roles/README.md
@@ -40,7 +40,7 @@ Delivery Management
 - [Principal Delivery Manager](principal_delivery_manager.md)
 
 Leadership
-- Head of Delivery Management
+- [Head of Delivery Management](head_of_delivery_management.md)
 
 ## User-Centred Practice
 

--- a/roles/head_of_delivery_management.md
+++ b/roles/head_of_delivery_management.md
@@ -1,0 +1,93 @@
+# Head of Delivery Management
+
+UK-wide with offices in Bristol, London, Manchester and Swansea.
+
+Our Head of Delivery Management is responsible for managing all client delivery. They head the Delivery Management Organisation which is responsible for connecting Industry and Capability Practices to ensure we maintain high quality standards and continually mitigate risks in order to deliver successful outcomes.
+
+To foster collaboration across Capability Practices, the Delivery Management Organisation is responsible for facilitating creation of cross-capability materials and training. They are responsible for growing the delivery management team ahead of demand, managing the performance of delivery experts and supporting career development.
+
+## Outcomes
+
+The Delivery Management Organisation (DMO) has a set of outcomes and KPIs that work towards our organisational purpose, vision and missions. To be successful the DMO must work as one team with Industry Practices, Capability Practices and Business Services as well as with clients.
+
+Key outcomes for the Head of Delivery Managment and the DMO:
+
+- Manage quality and risk of all delivery as we scale
+- Growth of delivery management team headcount slightly ahead of demand
+- Maximise utilisation and make the most of bench time by investing it to support sales, career development and training of delivery managers, and continuous improvement of the Delivery Management Organisation
+- Maximise retention of delivery managers by building a strong delivery identity and career pathways
+- Balance retention and profitability to grow a healthy delivery organisation while minimising costs
+
+## Responsibilities
+
+The Head of Delivery Management is responsible for delivering the above outcomes by collaborating with the business. They are responsible to the Executive Director for Delivery and Capabilities who is their line manager and representative in the Executive Committee.
+
+Strategy
+- Contribute to annual and quarter planning
+
+Service Delivery and Delivery Assurance
+- Manage delivery across all workstreams by embedding delivery managers into Industry Practices
+- Report to Executive Committee on a weekly basis the status of quality and risk across all deliveries
+- Facilitate creation of set of centralised resources with capabilities
+
+Hiring and Careers
+- Scale supply of delivery managers ahead of demand
+- Management of delivery managers including performance, progression, career paths and succession planning
+- Make sure delivery managers are engaged and happy in their day to day
+
+Demand Generation
+- Bid support, quality assurance and sponsorship
+
+Community and Thought Leadership
+- Continuously evolve ways of working, techniques, and technologies based on data on successful outcomes delivered for clients and improve the experience of our practitioners
+- Foster thriving community of practice and shared identity
+Consistently deliver thought leadership content and work with marketing to promote and drive growth
+
+## Competencies
+
+The Head of Delivery Management role is expected to be filled by Principals or Directors operating at SFIA level 6 or above in all five competencies due to the high impact and scale this role operates at. In addition to this, the below competencies and behaviours will be expected.
+
+- Articulation and role modelling of values, purpose, and vision
+- Strategic thinking and planning
+- Commercial awareness
+- Time management including balancing multiple priorities
+- Performance management of direct and indirect reports
+- Prioritise diversity and inclusion in goals and day to day activity
+- Inspiring leadership and good communication
+- Trust building with your seniors, peers and juniors
+- Continuous improvement and feedback
+
+## What we will provide you
+
+Balancing life and work:
+
+* ✈️ [Flexible Holiday](../benefits/flexible_holiday.md) – We trust you to take as much holiday as you need
+* 🕰️ [Flexible Working Hours](../benefits/working_hours.md) – We are flexible with what hours you work
+* 🗓️ [Flexible Working Days](../benefits/flexible_working.md) – We are flexible to the amount of days you work in a week
+* 👶 [Flexible Parental Leave](../guides/welfare/parental_leave.md) – We provide flexible parental leave options
+* 👩‍💻 [Remote Working](../benefits/remote_working.md) – We offer part-time remote working for all our staff
+* 🤗 [Paid counselling](../guides/welfare/paid_counselling.md) – We offer paid counselling as well as financial and legal advice
+* 🏖️ [Paid anniversary break](../benefits/paid_anniversary_break.md) – We celebrate your 3 and 5 year anniversary with us by buying your family a holiday
+
+Making work as fabulous as possible:
+
+* 💻 [Work Ready](../benefits/work_ready.md) – We'll buy you a Macbook, ergonomic equipment, books, conferences, training, and more
+* 💡 [Learning](../guides/learning/README.md) – We offer 12 days per year of personal learning time and a £300 personal learning budget
+* 🍽️ [Friday Lunches](../benefits/friday_lunch.md) – We randomly match up 8 colleagues every Friday and pay for lunch
+* 🍻 [Friday Drinks](../benefits/friday_drinks.md) – We pay for social drinks on a Friday
+
+Compensating you fairly:
+
+* 💷 [Transparent Salary Bands](../roles/README.md) – We publish salary bands so you know you're being fairly compensated
+* 👌 [Annual Salary Reviews](../guides/compensation/salary_reviews.md) – We review your salary on an annual basis
+* ⛷️ [Pension Scheme](../benefits/pension_scheme.md) – We provide a pension scheme so you can save for your future and we'll contribute to it
+* 🚄 [Season Ticket Loan](../benefits/season_ticket_loan.md) – We provide loans to help you pay for your travel
+* 🚲 [Cycle To Work Scheme](../benefits/cycle_to_work_scheme.md) – We offer the cycle to work scheme to help pay for your bicycle
+* 🚕 [Expenses Paid](../guides/compensation/expenses.md) – Taxi to a meeting? Want to take a customer to lunch? Expenses are no hassle!
+
+## Salary
+
+The salary for this role is location dependant:
+
+UK: £100,000 - £121,500\
+London & South East: £105,000 - £127,575


### PR DESCRIPTION
## What

- [Add Head of Delivery Management role](https://github.com/madetech/handbook/commit/c2d59bfabeb751d71b443d4af7afa6171e333b22)
- [Add link to Head of Delivery Management role to role overview](https://github.com/madetech/handbook/commit/01a00039f87096da72a655f9401ab46481a80eec)

## Why

We are aiming for full coverage of Delivery and Capability roles in the Handbook. Look out for more PRs this week!