### PR TITLE
Add Head of Capability Practice role

### DIFF
--- a/roles/README.md
+++ b/roles/README.md
@@ -75,7 +75,7 @@ Design including interaction and service design
 
 Leadership
 
-- Head of Capability Practice, User-Centred
+- [Head of Capability Practice](head_of_capability_practice.md), User-Centred
 
 ## Cloud & Engineering Practice
 
@@ -100,7 +100,7 @@ Cloud Engineering
 
 Leadership
 
-- Head of Capability Practice, Cloud & Engineering
+- [Head of Capability Practice](head_of_capability_practice.md), Cloud & Engineering
 
 ## Data Practice
 
@@ -119,7 +119,7 @@ Data Science
 
 Leadership
 
-- Head of Capability Practice, Data
+- [Head of Capability Practice](head_of_capability_practice.md), Data
 
 ## Cyber Security Practice
 
@@ -130,7 +130,7 @@ Security Engineering
 
 Leadership
 
-- Head of Capability Practice, Cyber Security
+- [Head of Capability Practice](head_of_capability_practice.md), Cyber Security
 
 ## Operations and Finance
 

--- a/roles/head_of_capability_practice.md
+++ b/roles/head_of_capability_practice.md
@@ -1,0 +1,85 @@
+# Head of Capability Practice
+
+UK-wide with offices in Bristol, London, Manchester and Swansea.
+
+Our Heads of Capability Practices are responsible for building world class professional services practices and developing demand for a set of propositions and capabilities within a particular functional expertise such as user-centred design, product, software engineering, data, cyber security, and more.
+
+## Outcomes
+
+Capability Practices share a common set of outcomes and KPIs that work towards our organisational purpose, vision and missions. To be successful they must work as one team with Industry Practices, the Delivery Management Organisation and Business Services.
+
+- Generate public sector demand for a set of capabilities
+- High growth of revenue and headcount
+- Maximise utilisation and make the most of bench time by using it to invest in career development, training and sales
+- Maximise retention by building a strong practice identity and clearing defining career pathways
+- Balance retention and profitability to grow a healthy delivery organisation while minimising costs
+
+## Responsibilities
+
+A Head of Capability Practice is responsible for delivering the above outcomes by collaborating with the business. They are responsible to the Executive Director for Delivery and Capabilities who is their line manager and representative in the Executive Committee.
+
+Strategy
+- Contribute to annual and quarter planning
+
+Demand Generation
+- Develop and maintain capability and industry-specific go-to-markets and propositions
+- Work closely with industries to meet your growth target
+- Provide bid support, quality assurance and sponsorship
+
+Hiring and Careers
+- Scale supply of capability team ahead of demand
+- Management of capability staff including performance, progression, career paths and succession planning
+- Make sure their team are engaged and happy in their day to day
+
+Community and Thought Leadership
+- Continuously evolve ways of working, techniques, and technologies based on data on successful outcomes delivered for clients and improve the experience of our practitioners
+- Contribute to central resources in collaboration with the Delivery Management Organisation and other Capability Practices
+- Foster a thriving community of practice and shared identity
+- Consistently deliver thought leadership content and work with marketing to promote and drive growth
+
+## Competencies
+
+- Articulation and role modelling of values, purpose, and vision
+- Strategic thinking and planning
+- Commercial awareness
+- Time management including balancing multiple priorities
+- Performance management of direct and indirect reports
+- Prioritise diversity and inclusion in goals and day to day activity
+- Inspiring leadership and good communication
+- Trust building with your seniors, peers and juniors
+- Continuous improvement and feedback
+
+## What we will provide you
+
+Balancing life and work:
+
+* ✈️ [Flexible Holiday](../benefits/flexible_holiday.md) – We trust you to take as much holiday as you need
+* 🕰️ [Flexible Working Hours](../benefits/working_hours.md) – We are flexible with what hours you work
+* 🗓️ [Flexible Working Days](../benefits/flexible_working.md) – We are flexible to the amount of days you work in a week
+* 👶 [Flexible Parental Leave](../guides/welfare/parental_leave.md) – We provide flexible parental leave options
+* 👩‍💻 [Remote Working](../benefits/remote_working.md) – We offer part-time remote working for all our staff
+* 🤗 [Paid counselling](../guides/welfare/paid_counselling.md) – We offer paid counselling as well as financial and legal advice
+* 🏖️ [Paid anniversary break](../benefits/paid_anniversary_break.md) – We celebrate your 3 and 5 year anniversary with us by buying your family a holiday
+
+Making work as fabulous as possible:
+
+* 💻 [Work Ready](../benefits/work_ready.md) – We'll buy you a Macbook, ergonomic equipment, books, conferences, training, and more
+* 💡 [Learning](../guides/learning/README.md) – We offer 12 days per year of personal learning time and a £300 personal learning budget
+* 🍽️ [Friday Lunches](../benefits/friday_lunch.md) – We randomly match up 8 colleagues every Friday and pay for lunch
+* 🍻 [Friday Drinks](../benefits/friday_drinks.md) – We pay for social drinks on a Friday
+
+Compensating you fairly:
+
+* 💷 [Transparent Salary Bands](../roles/README.md) – We publish salary bands so you know you're being fairly compensated
+* 👌 [Annual Salary Reviews](../guides/compensation/salary_reviews.md) – We review your salary on an annual basis
+* ⛷️ [Pension Scheme](../benefits/pension_scheme.md) – We provide a pension scheme so you can save for your future and we'll contribute to it
+* 🚄 [Season Ticket Loan](../benefits/season_ticket_loan.md) – We provide loans to help you pay for your travel
+* 🚲 [Cycle To Work Scheme](../benefits/cycle_to_work_scheme.md) – We offer the cycle to work scheme to help pay for your bicycle
+* 🚕 [Expenses Paid](../guides/compensation/expenses.md) – Taxi to a meeting? Want to take a customer to lunch? Expenses are no hassle!
+
+## Salary
+
+The salary for this role is location dependant:
+
+- UK: £100,000 - £135,000
+- London & South East: £105,000 - £141,750


### PR DESCRIPTION
# What

- [Add Head of Capability Practice role](https://github.com/madetech/handbook/commit/645d4a9576fcf5729355617643c19c645eee461d)
- [Add link to Head of Capability Practice role to roles overview](https://github.com/madetech/handbook/pull/603/commits/175b5846275f6a68845f2c5e6bdda756d471946a)

# Why

We are aiming for full coverage of Delivery and Capability roles in the Handbook. Look out for more PRs this week!