### PR TITLE
Update Head of Delivery and Capability Practice responsibilities

### DIFF
--- a/roles/head_of_capability_practice.md
+++ b/roles/head_of_capability_practice.md
@@ -18,8 +18,10 @@ Capability Practices share a common set of outcomes and KPIs that work towards o
 
 A Head of Capability Practice is responsible for delivering the above outcomes by collaborating with the business. They are responsible to the Executive Director for Delivery and Capabilities who is their line manager and representative in the Executive Committee.
 
-Strategy
-- Contribute to annual and quarter planning
+Strategy and Management
+- Influence policy and strategy on behalf of the Capability Practice
+- Contribute to annual/quarter planning and be responsible for the delivery of goals
+- Support integration and collaboration of the Delivery Management Organisation and Capability Practices with each other and the wider organisation
 
 Demand Generation
 - Develop and maintain capability and industry-specific go-to-markets and propositions
@@ -28,14 +30,14 @@ Demand Generation
 
 Hiring and Careers
 - Scale supply of capability team ahead of demand
-- Management of capability staff including performance, progression, career paths and succession planning
-- Make sure their team are engaged and happy in their day to day
+- Management of capability team including performance, progression, career paths and succession planning
+- Maintain high-levels of motivation and retention in the capability team
 
 Community and Thought Leadership
-- Continuously evolve ways of working, techniques, and technologies based on data on successful outcomes delivered for clients and improve the experience of our practitioners
-- Contribute to central resources in collaboration with the Delivery Management Organisation and other Capability Practices
-- Foster a thriving community of practice and shared identity
+- Continuously improve service delivery and ways of working based on past successes and failures
+- Foster thriving community of practice and shared identity
 - Consistently deliver thought leadership content and work with marketing to promote and drive growth
+- Encourage cross-community and multi-disciplinary collaboration
 
 ## Competencies
 

--- a/roles/head_of_delivery_management.md
+++ b/roles/head_of_delivery_management.md
@@ -22,8 +22,10 @@ Key outcomes for the Head of Delivery Managment and the DMO:
 
 The Head of Delivery Management is responsible for delivering the above outcomes by collaborating with the business. They are responsible to the Executive Director for Delivery and Capabilities who is their line manager and representative in the Executive Committee.
 
-Strategy
-- Contribute to annual and quarter planning
+Strategy and Management
+- Influence policy and strategy on behalf of the Delivery Management Organisation
+- Contribute to annual/quarter planning and be responsible for the delivery of goals
+- Support integration and collaboration of the Delivery Management Organisation and Capability Practices with each other and the wider organisation
 
 Service Delivery and Delivery Assurance
 - Manage delivery across all workstreams by embedding delivery managers into Industry Practices
@@ -33,15 +35,16 @@ Service Delivery and Delivery Assurance
 Hiring and Careers
 - Scale supply of delivery managers ahead of demand
 - Management of delivery managers including performance, progression, career paths and succession planning
-- Make sure delivery managers are engaged and happy in their day to day
+- Maintain high-levels of motivation and retention in the delivery management team
 
 Demand Generation
 - Bid support, quality assurance and sponsorship
 
 Community and Thought Leadership
-- Continuously evolve ways of working, techniques, and technologies based on data on successful outcomes delivered for clients and improve the experience of our practitioners
+- Continuously improve service delivery and ways of working based on past successes and failures
 - Foster thriving community of practice and shared identity
-Consistently deliver thought leadership content and work with marketing to promote and drive growth
+- Consistently deliver thought leadership content and work with marketing to promote and drive growth
+- Encourage cross-community and multi-disciplinary collaboration
 
 ## Competencies
 


### PR DESCRIPTION
# What

- [Update responsibilities of Head of Delivery Management](https://github.com/madetech/handbook/commit/5103f383725d96803c1e3e30fe58a9bfcffe11e1)
- [Update responsibilities of Head of Capability Practice](https://github.com/madetech/handbook/commit/14f1522eee10a2e67151cdb5afe39d66d8e07e05)
- Ran copy through https://gender-decoder.katmatfield.com/ both roles are strongly feminine-coded, meaning no action needed as "the research suggests this will have only a slight effect on how appealing the job is to men, and will encourage women applicants."

# Why

- We add more strategic leadership responsibilities to cover the influencing of policy (as per SFIA guidance for level 6+)
- Include responsibility for delivery of goals as tested in 2022 Q4
- Include support of integration and collaboration between their business area, closely and not so closely related areas... as a changing organisation we need leaders to actively support change
- Replace use of word "happy" for goals of retention and motivation 
- Emphasise importance of collaboration between communities of practice and fostering multi-disciplinary culture
- Other minor changes to improve consistency of language