### PR TITLE
Update friday_lunch.md

### DIFF
--- a/benefits/friday_lunch.md
+++ b/benefits/friday_lunch.md
@@ -1,12 +1,12 @@
 FRIDAY LUNCHERS
 
->Every Friday we select a number of people from each region to have a team lunch. This weekly ritual provides an opportunity for the team to socialise and share their successes and challenges from the week that's passed. It's important that we continue to set aside the time for this, especially when we're all working remotely.
+>Every Friday we select five people from each region to have a team lunch and join any new starters from that week. This weekly ritual provides an opportunity for the team to socialise and share their successes and challenges from the week that's passed. It's important that we continue to set aside the time for this, especially when we're all working remotely.
 
 **How it works:**
 
 The People team will organise lunches, inviting people from each region: you can only expense your lunch if invited to do so by them.
-While we're working remotely, just order from your favourite restaurant (up to a maximum of £20).
+While we're working remotely, order from your favourite restaurant, or purchasing ingredients from a supermarket (up to a maximum of £20) and expense that back using Xero.
 
-Any questions, ask your region's Community Manager
+Any questions, ask the People or Finance teams.
 
-*Policy owners: Community Managers* 
+*Policy owners: People & Culture advisor(s)* 


### PR DESCRIPTION
FRIDAY LUNCHERS

>Every Friday we select five people from each region to have a team lunch and join any new starters from that week. This weekly ritual provides an opportunity for the team to socialise and share their successes and challenges from the week that's passed. It's important that we continue to set aside the time for this, especially when we're all working remotely.

**How it works:**

The People team will organise lunches, inviting people from each region: you can only expense your lunch if invited to do so by them.
While we're working remotely, order from your favourite restaurant, or purchasing ingredients from a supermarket (up to a maximum of £20) and expense that back using Xero.

Any questions, ask the People or Finance teams.

*Policy owners: People & Culture advisor(s)* 