### PR TITLE
Update working_hours.md

### DIFF
--- a/benefits/working_hours.md
+++ b/benefits/working_hours.md
@@ -6,9 +6,9 @@ Some things to note:
 
  - We do not have a set amount of hours you need to work in a day or a week. Some people will work 6 hours, some 7, sometimes more than 8. Many of us will vary our hours day to day whilst others prefer routine.
 
- - We do not have a specific start time but we do have our All Hands Mondays and Fridays at 0950, and Wednesdays at 0930, so you should get into the office or dial in before that time in our #announcements Slack channel.
+ - We do not have a specific start time but we do have our Company Update on the first Wednesday of the month, and weekly Friday showcases. These are Wednesdays at 0930, and Fridays at 1630. So you should get into the office or dial in before those times.
 
- - Likewise there isn't a time we expect everyone to leave the office. Of course if you're leaving at 1630 every day and are having problems delivering on your commitments someone will likely provide you with feedback to help improve things.
+ - Likewise, there isn't a time we expect everyone to leave the office. Of course if you're leaving at 1630 every day and are having problems delivering on your commitments someone will likely provide you with feedback to help improve things.
 
  - Pressure can creep in around deadlines and sometimes staying late to ensure a smooth launch or to help diagnose and fix a problem is a necessity. However these occassions should be very rare. If you regularly feel this pressure, say more than twice a year then speak to a colleague.
 


### PR DESCRIPTION
# Working Hours

We care about the quality of the work we produce rather than the amount of hours worked. We believe we individually know how we work best and can therefore set our own hours.

Some things to note:

 - We do not have a set amount of hours you need to work in a day or a week. Some people will work 6 hours, some 7, sometimes more than 8. Many of us will vary our hours day to day whilst others prefer routine.

 - We do not have a specific start time but we do have our Company Update on the first Wednesday of the month, and weekly Friday showcases. These are Wednesdays at 0930, and Fridays at 1630. So you should get into the office or dial in before those times.

 - Likewise, there isn't a time we expect everyone to leave the office. Of course if you're leaving at 1630 every day and are having problems delivering on your commitments someone will likely provide you with feedback to help improve things.

 - Pressure can creep in around deadlines and sometimes staying late to ensure a smooth launch or to help diagnose and fix a problem is a necessity. However these occasions should be very rare. If you regularly feel this pressure, say more than twice a year, then speak to a colleague or your line manager.

 - Pressure can also arise when peers work seemingly longer hours than yourself. All we can suggest is that we have open and honest ways of providing feedback so unless someone has raised an issue with you, you're likely doing fine.

 - We need to respect our commitments so if we have a meeting booked for a certain time you are expected to be accommodating. This isn't to say you can't be responsible for setting meeting times that fit your working style better.

 - If you are taking a half day, read about our [flexible holiday](flexible_holiday.md)

 - It's worth noting most of our employment contracts with staff do in fact have set contractual hours. This is so we can withdraw this privilege if necessary.