### PR TITLE
Incorrect unified memory

### DIFF
--- a/guides/it/Hardware.md
+++ b/guides/it/Hardware.md
@@ -10,7 +10,7 @@ The current standard laptop specs for new purchases are:
 **Engineers and UCD**
 - 14‐inch MacBook Pro
 - Apple M1 Pro with 8-core CPU, 14-core GPU, 16-core Neural Engine
-- 32GB unified memory
+- 16GB unified memory
 - 512GB SSD storage
 
 OR


### PR DESCRIPTION
MacBook Pro comes as standard with 16GB of memory and it can be upgraded to more, but I believe that is not the case since the Mac that I've received from Systemagic has 16GB.