### PR TITLE
Improve whitespace & formatting consistencies & typos 

### DIFF
--- a/benefits/pension_scheme.md
+++ b/benefits/pension_scheme.md
@@ -1,11 +1,10 @@
- # Pension Scheme
+# Pension Scheme
 
-We have introduced a much-improved pension offering for all employees (as of May 2022). The workplace pension scheme is run by Scottish Widows and follows a contribution matching model where Made Tech matches the level of contribution you decide to make. 
+We have introduced a much-improved pension offering for all employees (as of May 2022). The workplace pension scheme is run by Scottish Widows and follows a contribution matching model where Made Tech matches the level of contribution you decide to make.
 
-The pension contribution available to you is aligned to your SFIA level, with pensions for SFIA 2-4 being up to 12% (6% matched), pensions for SFIA 5 being up to 14% (7% matched), pensions for SFIA 6 being up to 16% (8% matched) and pensions for SFIA 7 being up to 18% (9% matched). 
+The pension contribution available to you is aligned to your SFIA level, with pensions for SFIA 2-4 being up to 12% (6% matched), pensions for SFIA 5 being up to 14% (7% matched), pensions for SFIA 6 being up to 16% (8% matched) and pensions for SFIA 7 being up to 18% (9% matched).
 
 Our pension scheme is based on a salary sacrifice approach which is more tax-efficient for both employer and employee. We have removed the qualifying earnings limit, which should simplify pension management for those of you who are higher rate taxpayers. If you want to calculate your contributions you can use the calculator on the [Scottish Widows](https://www.scottishwidows.co.uk/retirement/calculators-tools/how-do-you-pay-to-your-pension/salary-sacrifice/) website.
-
 
 - In order to allocate your preferred contribution, or opt out, there is a form shared during onboarding for new starters to complete. You can opt out at any point by e mailing finance@madetech.com, copying in people@madetech.com.
 

--- a/benefits/pension_scheme.md
+++ b/benefits/pension_scheme.md
@@ -6,12 +6,12 @@ The pension contribution available to you is aligned to your SFIA level, with pe
 
 Our pension scheme is based on a salary sacrifice approach which is more tax-efficient for both employer and employee. We have removed the qualifying earnings limit, which should simplify pension management for those of you who are higher rate taxpayers. If you want to calculate your contributions you can use the calculator on the [Scottish Widows](https://www.scottishwidows.co.uk/retirement/calculators-tools/how-do-you-pay-to-your-pension/salary-sacrifice/) website.
 
-- In order to allocate your preferred contribution, or opt out, there is a form shared during onboarding for new starters to complete. You can opt out at any point by e mailing finance@madetech.com, copying in people@madetech.com.
+- In order to allocate your preferred contribution, or opt out, there is a form shared during onboarding for new starters to complete. You can opt out at any point by emailing finance@madetech.com, copying in people@madetech.com.
 
-- You will be able to adjust your contribution level in a set window in spring (open to all) annually, or at any point in the case of significant life events where this may result in a change in financial circumstances. If you are affected by the latter please e mail finance@madetech.com and copy in people@madetech.com
+- You will be able to adjust your contribution level in a set window in spring (open to all) annually, or at any point in the case of significant life events where this may result in a change in financial circumstances. If you are affected by the latter please email finance@madetech.com and copy in people@madetech.com
 
 - There are also [Government guidelines](https://www.gov.uk/workplace-pensions/if-you-want-to-leave-your-workplace-pension-scheme) on doing so here
 - You can read more about Workplace pensions on [gov.uk](https://www.gov.uk/workplace-pensions/about-workplace-pensions)
 - You can read more about Pensions and some third party advice on [MoneySavingExpert](http://www.moneysavingexpert.com/savings/discount-pensions)
 
-For any general pensions queries please e mail finance@madetech.com
+For any general pensions queries please email finance@madetech.com

--- a/guides/chalet_time_policy.md
+++ b/guides/chalet_time_policy.md
@@ -107,7 +107,7 @@ Different parts of the business will be responsible for making people aware of a
 
 #### 1. New opportunities on client teams
 
-A list of live accounts, teams and leads will be automatically published from Kimble to [`#chalet-time-team` Slack channel][1] Slack channel at the beginning of each week. This will give people a list of people to approach about potentially opportunities to join client teams.
+A list of live accounts, teams and leads will be automatically published from Kimble to [`#chalet-time-team`][1] Slack channel at the beginning of each week. This will give people a list of people to approach about potentially opportunities to join client teams.
 
 Line managers of people with chalet time will help find opportunities and advocate for them to join client teams, either billed, invested or shadowing
 

--- a/guides/chalet_time_policy.md
+++ b/guides/chalet_time_policy.md
@@ -1,51 +1,63 @@
- # Chalet time policy
-This document describes where and how people should spend time when not on client work -  known as chalet time. The purpose is to make sure people use this time to build their skills, grow Made Tech’s business and contribute to communities of practice.  
+# Chalet time policy
+
+This document describes where and how people should spend time when not on client work -  known as chalet time. The purpose is to make sure people use this time to build their skills, grow Made Tech’s business and contribute to communities of practice.
+
 ## What is chalet time?
-Chalet time is when people are not on client work. 
+
+Chalet time is when people are not on client work.
 For example, there is a two week gap for someone finishing the software engineering academy and going onto a client project. Another example, a Lead Designer having three days between their current client project and the next.
 
-Occasional chalet time is part of a business like ours, as client work isn’t always going to perfectly match our skills and who is available to work in different teams. 
-However, used the right way, chalet time can be valuable to grow skills, our business and contribute to communities of practice.  
+Occasional chalet time is part of a business like ours, as client work isn’t always going to perfectly match our skills and who is available to work in different teams.
+However, used the right way, chalet time can be valuable to grow skills, our business and contribute to communities of practice.
 
 ## Responsibility for using chalet time usefully
-People with chalet time and their line managers will be responsible to ensure this time is used usefully. 
+
+People with chalet time and their line managers will be responsible to ensure this time is used usefully.
 
 Line management should therefore focussed partly on:
-- Agree weekly goals to use chalet time according the highest priorities 
+
+- Agree weekly goals to use chalet time according the highest priorities
 - Check together progress against goals for chalet time in Small Improvements
 - Agree a plan to get someone onto billed client work
 - Identify blockers someone has doing activities with their chalet time
-- Identify where the organisation someone needs their line manager to introduce them to and in some situations advocare for them to join 
+- Identify where the organisation someone needs their line manager to introduce them to and in some situations advocare for them to join
 
-Each Head of Capability Practice is ultimately accountable for everyone in their practice using chalet time the right way.  This will be measured by the average people’s time is billed to a client, also known as utilisation. Heads of Capability Practices will report each week how people are using chalet time, as part of weekly utilisation meetings with Operations. 
+Each Head of Capability Practice is ultimately accountable for everyone in their practice using chalet time the right way.  This will be measured by the average people’s time is billed to a client, also known as utilisation. Heads of Capability Practices will report each week how people are using chalet time, as part of weekly utilisation meetings with Operations.
 
 ## Priorities for chalet time
-The priorities for using chalet time will always stay the same, but what activities you do will depend on your roles and availability. 
-If there are no activities that need to be done that match your role and availability, chalet time should be used for the next highest priority. For example, if there are no activities that someone could do to find new opportunities on client teams or new business and revenue, people would do hiring activities. 
+
+The priorities for using chalet time will always stay the same, but what activities you do will depend on your roles and availability.
+If there are no activities that need to be done that match your role and availability, chalet time should be used for the next highest priority. For example, if there are no activities that someone could do to find new opportunities on client teams or new business and revenue, people would do hiring activities.
 
 Priorities for chalet time:
 
 #### 1. New opportunities on client teams
+
 1. Billed opportunities, where clients pay for someone’s time
 2. Invested opportunities, working on a client team, but not billed to begin with, showing value first
 3. Shadowing, getting experience of how teams work
 
 #### 2. New business and revenue
+
 1. Bid writing - leading / pairing / shadowing / case studies / research
 2. Support marketing team create content, like blogging, case studies, talks that promote Made Tech
 
 #### 3. Hiring
+
 1. Pairing on interviews
 2. Outreach to potential candidates
 
 #### 4. Research and development
-1. Product development 
+
+1. Product development
 2. Research projects
 
 #### 5. Communities of practice
+
 - [Communities Improvements Backlog](https://trello.com/b/taj8yvLP/capability-improvement-backlog)
 
 #### 6. Learning time
+
 - Reading
 - Training courses
 - Conferences
@@ -54,64 +66,75 @@ Priorities for chalet time:
 #### 7. Holiday that can flexibly be moved
 
 ## Booking or scheduling chalet time
+
 Chalet time activities will be booked and scheduled as follows:
 
 #### 1. New opportunities on client teams
+
 Billed or invested time - like other times someone joins a client team this will be booked by the Scheduling team and the individual will fill out timesheets for time spent in this team
 
 Shadowing - this time should be recorded as ‘Bench/Chalet’ time in timesheets
 
 #### 2. New business and revenue
+
 Bid writing - booked by the Scheduling team and the individual will fill out timesheets for time spent on a bid
 
 Marketing - this time should be recorded as ‘Bench/Chalet’ in timesheets
 
 #### 3. Hiring
+
 This time should be recorded as ‘Hiring’ in timesheets
 
 #### 4. Research and development
+
 This time should be recorded as ‘R&D’ time in timesheets
 
 #### 5. Communities of practice
+
 Doing activities on the [Communities Improvements Backlog](https://trello.com/b/taj8yvLP/capability-improvement-backlog) this should be recorded as ‘Bench/Chalet’ in timesheets
 
 #### 6. Learning time
-People with chalet time will [book learning time](https://github.com/madetech/handbook/blob/main/guides/learning/booking_learning_time.md) in the normal way. 
+
+People with chalet time will [book learning time](https://github.com/madetech/handbook/blob/main/guides/learning/booking_learning_time.md) in the normal way.
 
 #### 7. Holiday
-People with chalet time will [book holiday](https://github.com/madetech/handbook/blob/main/benefits/flexible_holiday.md) as they would any other holiday or leave. 
 
-## Responsibility to make activities visible and  doable 
+People with chalet time will [book holiday](https://github.com/madetech/handbook/blob/main/benefits/flexible_holiday.md) as they would any other holiday or leave.
+
+## Responsibility to make activities visible and  doable
+
 Different parts of the business will be responsible for making people aware of activities they can do with chalet time:
 
 #### 1. New opportunities on client teams
 
-A list of live accounts, teams and leads will be automatically published from Kimble to [`#chalet-time-team` Slack channel][1] Slack channel at the beginning of each week. This will give people a list of people to approach about potentially opportunities to join client teams. 
+A list of live accounts, teams and leads will be automatically published from Kimble to [`#chalet-time-team` Slack channel][1] Slack channel at the beginning of each week. This will give people a list of people to approach about potentially opportunities to join client teams.
 
 Line managers of people with chalet time will help find opportunities and advocate for them to join client teams, either billed, invested or shadowing
 
 #### 2. New revenue and business
+
 Bids team will update the Scheduling team each week of bids people with chalet time can get involved with
 
-Marketing team will maintain a visible backlog of tasks people with chalet time can do to help promote Made Tech. This will be posted in the [`#chalet-time-team`][1] Slack channel at the beginning of each week. 
+Marketing team will maintain a visible backlog of tasks people with chalet time can do to help promote Made Tech. This will be posted in the [`#chalet-time-team`][1] Slack channel at the beginning of each week.
 
 #### 3. Hiring
+
 Scheduling team will give the Talent team coordinators access to the Kimble report of who has chalet to do extra hiring interviews or require training to do so
 
-Scheduling team will giving the Talent team coordinators access to the Kimble report of who’s has chalet 
+Scheduling team will giving the Talent team coordinators access to the Kimble report of who’s has chalet
 
 #### 4. Research and development
 
-The R&D team will maintain a visible backlog of tasks people with chalet time can do either to help build products or research new opportunities. This will be posted in the [`#chalet-time-team`][1] Slack channel at the beginning of each week. 
+The R&D team will maintain a visible backlog of tasks people with chalet time can do either to help build products or research new opportunities. This will be posted in the [`#chalet-time-team`][1] Slack channel at the beginning of each week.
 
 ##### 5. Communities of practice
 
-Capability and Delivery Heads will maintain a [visible backlog of tasks](https://trello.com/b/taj8yvLP/capability-improvement-backlog) people with chalet time can undertake to improve their community of practice. This will be posted weekly in both [`#chalet-time-team`][1] and [`#cop-improvements-backlog`](https://madetechteam.slack.com/archives/C03BMF2E39S) Slack channels 
+Capability and Delivery Heads will maintain a [visible backlog of tasks](https://trello.com/b/taj8yvLP/capability-improvement-backlog) people with chalet time can undertake to improve their community of practice. This will be posted weekly in both [`#chalet-time-team`][1] and [`#cop-improvements-backlog`](https://madetechteam.slack.com/archives/C03BMF2E39S) Slack channels
 
 ## Length of chalet time activities
-Chalet time activities must be able to deliver some value in small blocks of time: half day, single day or 3-5 days, eaning chalet time can add value if someone joins a client team at short notice. 
+
+Chalet time activities must be able to deliver some value in small blocks of time: half day, single day or 3-5 days, eaning chalet time can add value if someone joins a client team at short notice.
 
 Some activities may need more than a week but still be able to deliver business or personal value in increments of a half day, single day or 3-5 days.
-
 
 [1]: https://madetechteam.slack.com/archives/C03F23K2RL0

--- a/guides/chalet_time_policy.md
+++ b/guides/chalet_time_policy.md
@@ -71,27 +71,27 @@ Chalet time activities will be booked and scheduled as follows:
 
 #### 1. New opportunities on client teams
 
-Billed or invested time - like other times someone joins a client team this will be booked by the Scheduling team and the individual will fill out timesheets for time spent in this team
+Billed or invested time - like other times someone joins a client team this will be booked by the Scheduling team and the individual will fill out timesheets for time spent in this team.
 
-Shadowing - this time should be recorded as ‘Bench/Chalet’ time in timesheets
+Shadowing - this time should be recorded as ‘Bench/Chalet’ time in timesheets.
 
 #### 2. New business and revenue
 
-Bid writing - booked by the Scheduling team and the individual will fill out timesheets for time spent on a bid
+Bid writing - booked by the Scheduling team and the individual will fill out timesheets for time spent on a bid.
 
-Marketing - this time should be recorded as ‘Bench/Chalet’ in timesheets
+Marketing - this time should be recorded as ‘Bench/Chalet’ in timesheets.
 
 #### 3. Hiring
 
-This time should be recorded as ‘Hiring’ in timesheets
+This time should be recorded as ‘Hiring’ in timesheets.
 
 #### 4. Research and development
 
-This time should be recorded as ‘R&D’ time in timesheets
+This time should be recorded as ‘R&D’ time in timesheets.
 
 #### 5. Communities of practice
 
-Doing activities on the [Communities Improvements Backlog](https://trello.com/b/taj8yvLP/capability-improvement-backlog) this should be recorded as ‘Bench/Chalet’ in timesheets
+Doing activities on the [Communities Improvements Backlog](https://trello.com/b/taj8yvLP/capability-improvement-backlog) this should be recorded as ‘Bench/Chalet’ in timesheets.
 
 #### 6. Learning time
 
@@ -109,19 +109,19 @@ Different parts of the business will be responsible for making people aware of a
 
 A list of live accounts, teams and leads will be automatically published from Kimble to [`#chalet-time-team`][1] Slack channel at the beginning of each week. This will give people a list of people to approach about potentially opportunities to join client teams.
 
-Line managers of people with chalet time will help find opportunities and advocate for them to join client teams, either billed, invested or shadowing
+Line managers of people with chalet time will help find opportunities and advocate for them to join client teams, either billed, invested or shadowing.
 
 #### 2. New revenue and business
 
-Bids team will update the Scheduling team each week of bids people with chalet time can get involved with
+Bids team will update the Scheduling team each week of bids people with chalet time can get involved with.
 
 Marketing team will maintain a visible backlog of tasks people with chalet time can do to help promote Made Tech. This will be posted in the [`#chalet-time-team`][1] Slack channel at the beginning of each week.
 
 #### 3. Hiring
 
-Scheduling team will give the Talent team coordinators access to the Kimble report of who has chalet to do extra hiring interviews or require training to do so
+Scheduling team will give the Talent team coordinators access to the Kimble report of who has chalet to do extra hiring interviews or require training to do so.
 
-Scheduling team will giving the Talent team coordinators access to the Kimble report of who’s has chalet
+Scheduling team will giving the Talent team coordinators access to the Kimble report of who’s has chalet.
 
 #### 4. Research and development
 
@@ -129,7 +129,7 @@ The R&D team will maintain a visible backlog of tasks people with chalet time ca
 
 ##### 5. Communities of practice
 
-Capability and Delivery Heads will maintain a [visible backlog of tasks](https://trello.com/b/taj8yvLP/capability-improvement-backlog) people with chalet time can undertake to improve their community of practice. This will be posted weekly in both [`#chalet-time-team`][1] and [`#cop-improvements-backlog`](https://madetechteam.slack.com/archives/C03BMF2E39S) Slack channels
+Capability and Delivery Heads will maintain a [visible backlog of tasks](https://trello.com/b/taj8yvLP/capability-improvement-backlog) people with chalet time can undertake to improve their community of practice. This will be posted weekly in both [`#chalet-time-team`][1] and [`#cop-improvements-backlog`](https://madetechteam.slack.com/archives/C03BMF2E39S) Slack channels.
 
 ## Length of chalet time activities
 

--- a/guides/chalet_time_policy.md
+++ b/guides/chalet_time_policy.md
@@ -133,7 +133,7 @@ Capability and Delivery Heads will maintain a [visible backlog of tasks](https:/
 
 ## Length of chalet time activities
 
-Chalet time activities must be able to deliver some value in small blocks of time: half day, single day or 3-5 days, eaning chalet time can add value if someone joins a client team at short notice.
+Chalet time activities must be able to deliver some value in small blocks of time: half day, single day or 3-5 days, meaning chalet time can add value if someone joins a client team at short notice.
 
 Some activities may need more than a week but still be able to deliver business or personal value in increments of a half day, single day or 3-5 days.
 

--- a/guides/chalet_time_policy.md
+++ b/guides/chalet_time_policy.md
@@ -133,8 +133,8 @@ Capability and Delivery Heads will maintain a [visible backlog of tasks](https:/
 
 ## Length of chalet time activities
 
-Chalet time activities must be able to deliver some value in small blocks of time: half day, single day or 3-5 days, meaning chalet time can add value if someone joins a client team at short notice.
+Chalet time activities must be able to deliver some value in small blocks of time: half day, single day or 3–5 days, meaning chalet time can add value if someone joins a client team at short notice.
 
-Some activities may need more than a week but still be able to deliver business or personal value in increments of a half day, single day or 3-5 days.
+Some activities may need more than a week but still be able to deliver business or personal value in increments of a half day, single day or 3–5 days.
 
 [1]: https://madetechteam.slack.com/archives/C03F23K2RL0

--- a/guides/line-management/probation.md
+++ b/guides/line-management/probation.md
@@ -70,7 +70,7 @@ Feedback can be difficult to get. If it's not clear whether they are on-track fo
 
 ## Finishing probation
 
-Make a recommendation on behalf of your direct report to your 'Head of'. This would usually be by e mail and copy the people team in.
+Make a recommendation on behalf of your direct report to your 'Head of'. This would usually be by email and copy the people team in.
 
 Highlight feedback from the team about them and a short summary of how they demonstrated meeting or exceeding their role expectations and our core values. Be sure to include balanced feedback that also includes areas for development or further focus and growth for your team member based on the feedback provided or that you have observed as line manager.
 
@@ -78,7 +78,7 @@ Your 'Head of' will make the final decision on whether to pass, extend, or fail 
 
 ### Passing probation
 
-Once your Head of has confirmed they agree with your recommendation to pass probation, congratulate them on passing probation. Confirm their new notice period (this will be in the e mail from the people team too).
+Once your Head of has confirmed they agree with your recommendation to pass probation, congratulate them on passing probation. Confirm their new notice period (this will be in the email from the people team too).
 
 Decide together how often to have one-to-ones from now on (we'd recommend a minimum of monthly).
 

--- a/guides/line-management/probation.md
+++ b/guides/line-management/probation.md
@@ -28,7 +28,7 @@ Before the end of the probation period you must have confidence that the team me
 ### Week 6
 
 This is a great time for a half way review. Discuss how their time has gone so far, reflect and review on feedback and work examples you have already discussed and identify what you want to focus on for the following 6 weeks.
-Feedback is easier to receive if you give colleagues a heads up and a chance to better observe you. Send out a probation feedback request to the team leads, peers and other stakeholders they work with via Small Improvements asking to observe the team member for the following 4 - 6 week. A template 'Probation Feedback' is available to use'.
+Feedback is easier to receive if you give colleagues a heads up and a chance to better observe you. Send out a probation feedback request to the team leads, peers and other stakeholders they work with via Small Improvements asking to observe the team member for the following 4 - 6 week. A template 'Probation Feedback' is available to use.
 
 ### Week 10
 

--- a/guides/line-management/probation.md
+++ b/guides/line-management/probation.md
@@ -13,43 +13,45 @@ This guidance is written for line managers, but may be useful for people on prob
 - [One-to-one meetings during probation](#one-to-one-121-meetings-during-probation)
 - [Finishing probation](#finishing-probation)
 
-
 ## What happens during probation?
 
 In the first week, explain probation to your direct report. Talk about what it is, and how to pass it.
 
-
 Each week, meet them one-to-one.
-Get feedback from their team, and reflect on it together. You should clarify the need for constructive feedback here - it's important to set progression goals and this helps identifying areas for development. 
+Get feedback from their team, and reflect on it together. You should clarify the need for constructive feedback here - it's important to set progression goals and this helps identifying areas for development.
 Ensure clarity on role expectations and core values.
-Talk often about whether they're on-track to pass. 
+Talk often about whether they're on-track to pass.
 Be honest and upfront about concerns or skills gaps and support your direct report by providing clarity on what those are, and discuss finding opportunities for them to demonstrate progress.
 
 Before the end of the probation period you must have confidence that the team member meets their role expectations and is aligned with our core values. Demonstrating both of these generally means that they are a great addition to our team and will help drive the company goals forward. Absence of either of those needs to be looked into more closely.
 
 ### Week 6
+
 This is a great time for a half way review. Discuss how their time has gone so far, reflect and review on feedback and work examples you have already discussed and identify what you want to focus on for the following 6 weeks.
-Feedback is easier to receive if you give colleagues a heads up and a chance to better observe you. Send out a probation feedback request to the team leads, peers and other stakeholders they work with via Small Improvements asking to observe the team member for the following 4 - 6 week. A template 'Probation Feedback' is available to use'. 
+Feedback is easier to receive if you give colleagues a heads up and a chance to better observe you. Send out a probation feedback request to the team leads, peers and other stakeholders they work with via Small Improvements asking to observe the team member for the following 4 - 6 week. A template 'Probation Feedback' is available to use'.
 
 ### Week 10
+
 It's time to review the feedback you have received over the past few weeks. If you are missing feedback then this is a good time to nudge colleagues.
-Reviewing the feedback during week 10 will allow a further 2 weeks (week 12 is your probation review) to reflect and work through anything that is unclear or outstanding. 
+Reviewing the feedback during week 10 will allow a further 2 weeks (week 12 is your probation review) to reflect and work through anything that is unclear or outstanding.
 
 ### Week 10 - 12
-Please see 'Finishing probation' below. 
+
+Please see 'Finishing probation' below.
 
 ## Explaining how to pass probation
 
 Talk about what good looks like for your direct report's role. [The handbook role pages](../../roles/README.md) may help with this.
 It's good to spend the first two weeks talking about this.
 
-Explain that feedback is useful evidence on how they're performing. 
+Explain that feedback is useful evidence on how they're performing.
 
 Tell them to ask their team for feedback. You can talk to their team directly to help get more feedback, if needed.
 
 ### Worries about failing probation
 
 It can be stressful to be on probation. Explain early that:
+
 - Most people pass
 - Getting regular feedback means the result won't be a surprise
 - You will guide and support them
@@ -59,6 +61,7 @@ It can be stressful to be on probation. Explain early that:
 Read our [general guidance for 121 meetings](./121s.md).
 
 In probation, focus more on:
+
 - Giving and receiving feedback
 - Reflecting on feedback together
 - Whether they're on-track to pass
@@ -67,7 +70,7 @@ Feedback can be difficult to get. If it's not clear whether they are on-track fo
 
 ## Finishing probation
 
-Make a recommendation on behalf of your direct report to your 'Head of'. This would usually be by e mail and copy the people team in. 
+Make a recommendation on behalf of your direct report to your 'Head of'. This would usually be by e mail and copy the people team in.
 
 Highlight feedback from the team about them and a short summary of how they demonstrated meeting or exceeding their role expectations and our core values. Be sure to include balanced feedback that also includes areas for development or further focus and growth for your team member based on the feedback provided or that you have observed as line manager.
 


### PR DESCRIPTION
Some minor changes, including:
- Removal of redundant whitespace (at the start and end of files and some lines)
- Blank line after headings and before lists
- Updated `e mail` to `email` as the latter is used much more widely within the handbook
- Added full stops for consistency

When viewing the changes it is best to view them excluding whitespace.