### PR TITLE
Fix Made Tech spelling

### DIFF
--- a/roles/sfia/lead_user_researcher.md
+++ b/roles/sfia/lead_user_researcher.md
@@ -73,14 +73,14 @@ Below are examples of behaviours and responsibilities a person in this role migh
 
 - Wide range of quantitative and qualitative experience, expertise in a wide range of research methodologies
 - Can fully explain the purpose and activities of each GDS phase of service delivery and the role of user researchers to clients unfamiliar or uncomfortable with that way of working.
-- Takes responsibility for exploring and trialling new tools and techniques that will continue to push the growth of user research at Madetech
+- Takes responsibility for exploring and trialling new tools and techniques that will continue to push the growth of user research at Made Tech
 - Trusted and approachable user research expert that clients and internal folk approach for support and advice
 - Understands how to measure the impact and effectiveness of user research at Made Tech and the things we can do to improve as a team
 - Able to plan and manage user research on complex programmes of work
 - Responsible for the standards and ethical conduct of user research here at Made Tech
 - Confident in carrying out user research with vulnerable and marginalised groups
 - Uses insights to inform strategic direction
-- Able to assess the suitability of potential candidates for user research roles at Madetech
+- Able to assess the suitability of potential candidates for user research roles at Made Tech
 
 ### Business Skills
 
@@ -94,5 +94,5 @@ Below are examples of behaviours and responsibilities a person in this role migh
 - Trustworthy, acts with integrity, openness and impartiality with research participants
 - Able to navigate and handle conflict within teams and with clients
 - Leads proposal writing around UCD activities with the sales team
-- Confident at pitch presentations and selling Madetech in front of clients
-- Able to give constructive feedback to senior management to continue to improve how we develop and grow UCD at Madetech
+- Confident at pitch presentations and selling Made Tech in front of clients
+- Able to give constructive feedback to senior management to continue to improve how we develop and grow UCD at Made Tech

--- a/roles/sfia/lead_user_researcher.md
+++ b/roles/sfia/lead_user_researcher.md
@@ -1,30 +1,36 @@
-# SFIA Role Guidance: Lead User Researcher 
+# SFIA Role Guidance: Lead User Researcher
 
-- [SFIA Level 5](https://sfia-online.org/en/sfia-7/responsibilities/level-5): Ensure, Advise  
+- [SFIA Level 5](https://sfia-online.org/en/sfia-7/responsibilities/level-5): Ensure, Advise
 - [Job description](https://github.com/madetech/handbook/blob/main/roles/lead_user_researcher.md)
 
 ## Summary of role
+
 Our Lead User Researchers play a key role in scoping and managing multiple, complex user research projects in the public sector and supporting our sales time to sell new work to clients. They’re expert practitioners comfortable conducting and managing user research. They play an important role in creating an inclusive, nurturing and safe environment for our more junior user researchers to grow and develop. They are vocal and visible contributors to our user-centred design (UCD) community and culture at Made Tech.
+
 ## Required competency for role (with example behaviours)
 
 ### Autonomy
+
 Works without direction to guide their team on where to focus energy within strategy, research and design areas to deliver good public services. Takes responsibility for scoping, coordinating and supporting multiple user research projects.
+
 #### Examples of behaviour and responsibilities
+
 Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
 
 - Proactively requests feedback from the people they work with. Able to honestly self reflect
 - Practices open and honest communication, active listening and demonstrates empathy and patience
 - Take responsibility for accounts and programmes of work and embeds a no blame attitude in teams
-- Able to quickly assess what our clients need and the purpose and approach of user research and UCD on projects. 
+- Able to quickly assess what our clients need and the purpose and approach of user research and UCD on projects.
 - Able to connect project work to wider strategic goals
 - Builds and maintains strong relationship with clients and stakeholders
 
-### Influence 
+### Influence
 
-Clearly articulates the user research vision here at Made Tech and how it supports the business reaching its wider strategic goals. 
-Drives internal Made Tech teams and client teams towards research excellence by influencing individuals, stakeholders and partners. 
+Clearly articulates the user research vision here at Made Tech and how it supports the business reaching its wider strategic goals.
+Drives internal Made Tech teams and client teams towards research excellence by influencing individuals, stakeholders and partners.
 
 #### Examples of behaviour and responsibilities
+
 Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
 
 - Builds trust with our clients and quickly earns their respect
@@ -38,12 +44,14 @@ Below are examples of behaviours and responsibilities a person in this role migh
 - Shows they are role models for less senior researchers and set an example for how to be professional, supportive and effective
 
 ### Complexity
-Shift from project planning to programme planning. 
+
+Shift from project planning to programme planning.
 Leads multiple UCD teams on projects and wider programmes of work.
-Can balance competing priorities and projects. 
+Can balance competing priorities and projects.
 Holds the vision and strategy for projects and helps UCD teams navigate complex work and environments.
 
 #### Examples of behaviour and responsibilities
+
 Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
 
 - Supports teams to plan and scope user research activities, ensuring they align with the wider client strategy and Made Tech roadmap
@@ -55,10 +63,12 @@ Below are examples of behaviours and responsibilities a person in this role migh
 - Leads the delivery of user research
 - Explores and pushes the practice of user research here at Made Tech
 
-### Knowledge 
-Expert understanding of planning and applying quantitative and qualitative methodologies on complex programmes of UCD work. 
+### Knowledge
+
+Expert understanding of planning and applying quantitative and qualitative methodologies on complex programmes of UCD work.
 
 #### Examples of behaviour and responsibilities
+
 Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
 
 - Wide range of quantitative and qualitative experience, expertise in a wide range of research methodologies
@@ -66,19 +76,21 @@ Below are examples of behaviours and responsibilities a person in this role migh
 - Takes responsibility for exploring and trialling new tools and techniques that will continue to push the growth of user research at Madetech
 - Trusted and approachable user research expert that clients and internal folk approach for support and advice
 - Understands how to measure the impact and effectiveness of user research at Made Tech and the things we can do to improve as a team
-- Able to plan and manage user research on complex programmes of work 
+- Able to plan and manage user research on complex programmes of work
 - Responsible for the standards and ethical conduct of user research here at Made Tech
-- Confident in carrying out user research with vulnerable and marginalised groups 
-- Uses insights to inform strategic direction 
+- Confident in carrying out user research with vulnerable and marginalised groups
+- Uses insights to inform strategic direction
 - Able to assess the suitability of potential candidates for user research roles at Madetech
 
 ### Business Skills
+
 Is a trusted, honest and respected leader. Communicates effectively, both formally and informally. Is confident at selling UCD work in the public sector.
 
 #### Examples of behaviour and responsibilities
+
 Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
 
-- Regularly represents Made Tech in the wider UCD community through writing or speaking 
+- Regularly represents Made Tech in the wider UCD community through writing or speaking
 - Trustworthy, acts with integrity, openness and impartiality with research participants
 - Able to navigate and handle conflict within teams and with clients
 - Leads proposal writing around UCD activities with the sales team

--- a/roles/sfia/senior_user_researcher.md
+++ b/roles/sfia/senior_user_researcher.md
@@ -1,16 +1,20 @@
-# SFIA Role Guidance: Senior User Researcher 
+# SFIA Role Guidance: Senior User Researcher
 
 - [SFIA Level 4](https://sfia-online.org/en/sfia-7/responsibilities/level-4): Enable
 - [Job description](../senior_user_researcher.md)
 
 ## Summary of role
+
 Our Senior User Researchers play a key role in leading project teams and setting direction for project work. They’re expert practitioners, confident leading the planning and running of user research on complicated and large scale public sector projects. They are vocal and visible contributors to our user-centred design (UCD) community and culture at Made Tech.
 
 ## Required competency for role (with example behaviours)
+
 ### Autonomy
+
 Self-initates and works with little direction of where to focus energy to research, design and deliver good public services with their team. Takes responsibility for the team focusing their research in the right areas, using the most appropriate methodologies and expertise in guiding teams to producing the most impactful research outputs. Works with to define and assign research tasks to themselves and others.
 
-#### Examples of behaviour and responsibilities 
+#### Examples of behaviour and responsibilities
+
 Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
 
 - Proactively requests feedback from the people they work with. Able to honestly self reflect
@@ -21,14 +25,17 @@ Below are examples of behaviours and responsibilities a person in this role migh
 - Shares good practice from own experience and other sources for how and why a team does activities like in-depth interviews with users or low fidelity prototypes
 - Shows work at community show and tells
 
-### Influence 
+### Influence
+
 Drives team towards research excellence by influencing team, stakeholders and partners.
 
 Able to support teams making decisions based on balancing research evidence against organisational needs and constraints
 Identifies key stakeholders, tailoring communication to their needs. Ability to influence stakeholders and teams to practice user centred design in their organisation
 
-#### Examples of behaviour and responsibilities 
+#### Examples of behaviour and responsibilities
+
 Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
+
 - Able to hold and inform the strategic vision of our clients through user research
 - Works with the client to set team priorities for work
 - Able to create and share a clear, tangible and understandable vision for the role and direction of user research
@@ -38,9 +45,11 @@ Below are examples of behaviours and responsibilities a person in this role migh
 - Coaches less senior researchers taking on line management for the first time and how to grow into this new responsibility
 
 ### Complexity
-Leads user research with their team within a wider programme of work in multi-organisation stakeholder environments. Able to balance complex user and organsational needs and use research to inform design, strategy and processes.  
 
-#### Examples of behaviour and responsibilities 
+Leads user research with their team within a wider programme of work in multi-organisation stakeholder environments. Able to balance complex user and organsational needs and use research to inform design, strategy and processes.
+
+#### Examples of behaviour and responsibilities
+
 - Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
 - Confident managing complex stakeholder groups
 - Demonstrates understanding and empathy for stakeholders
@@ -50,29 +59,35 @@ Leads user research with their team within a wider programme of work in multi-or
 - Breaks down silos within their team and has UCD roles and people in other disciplines working towards the same goals.
 - Shares research with other delivery teams within the client organisation and shows the need for close coordination between teams
 
-### Knowledge 
-Deep understanding of user research quantitative and qualitative methodologies and is competent at understanding how and when to apply different approaches. 
+### Knowledge
+
+Deep understanding of user research quantitative and qualitative methodologies and is competent at understanding how and when to apply different approaches.
 Wide range of quantitative and qualitative experience, highly competent with a range of methodologies
 
-#### Examples of behaviour and responsibilities 
+#### Examples of behaviour and responsibilities
+
 Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
+
 - Understands how and when to apply different methodologies across the design cycle
 - Able to create appropriate, clear and compelling findings. Experienced in how to deliver them to reflect the needs of individual projects and clients and ensure strong outcomes
-- Experience working with other user centred design disciplines and a deep understanding of how user research works cohesively with these disciplines 
+- Experience working with other user centred design disciplines and a deep understanding of how user research works cohesively with these disciplines
 - Competent at the leading the planning of research approaches
 - Understanding of how to include and consider and involve traditionally marginalised and oppressed groups to deliver accessible services that work for all users
 - Deep understanding of conducting ethical and inclusive research and confident leading and upskilling teams
-- Can help teams understand the diversity of users of government services. Knows how to include all kinds of users in appropriate research activities. Can advocate for inclusive practices and help teams design 
+- Can help teams understand the diversity of users of government services. Knows how to include all kinds of users in appropriate research activities. Can advocate for inclusive practices and help teams design
 
 ### Business Skills
+
 Demonstrates leadership. Communicates effectively, both formally and informally
 
-#### Examples of behaviour and responsibilities 
+#### Examples of behaviour and responsibilities
+
 Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
+
 - Supports the development of user research at MadeTech
-- Represents Madetech in the wider UCD community through writing or speaking 
-- Trustworthy, acts with integrity, openness and impartiality 
+- Represents Madetech in the wider UCD community through writing or speaking
+- Trustworthy, acts with integrity, openness and impartiality
 - Able to navigate and handle conflict within teams and with stakeholders
 - Can help colleagues understand how digital technology is changing user behaviour, and the challenges and opportunities for government services.
 - Has knowledge of the technologies used to build and operate digital services. Can collaborate closely with colleagues in different digital disciplines
-- Supports the sales team in proposal writing 
+- Supports the sales team in proposal writing

--- a/roles/sfia/senior_user_researcher.md
+++ b/roles/sfia/senior_user_researcher.md
@@ -11,7 +11,7 @@ Our Senior User Researchers play a key role in leading project teams and setting
 
 ### Autonomy
 
-Self-initates and works with little direction of where to focus energy to research, design and deliver good public services with their team. Takes responsibility for the team focusing their research in the right areas, using the most appropriate methodologies and expertise in guiding teams to producing the most impactful research outputs. Works with to define and assign research tasks to themselves and others.
+Self-initiates and works with little direction of where to focus energy to research, design and deliver good public services with their team. Takes responsibility for the team focusing their research in the right areas, using the most appropriate methodologies and expertise in guiding teams to producing the most impactful research outputs. Works with to define and assign research tasks to themselves and others.
 
 #### Examples of behaviour and responsibilities
 
@@ -46,7 +46,7 @@ Below are examples of behaviours and responsibilities a person in this role migh
 
 ### Complexity
 
-Leads user research with their team within a wider programme of work in multi-organisation stakeholder environments. Able to balance complex user and organsational needs and use research to inform design, strategy and processes.
+Leads user research with their team within a wider programme of work in multi-organisation stakeholder environments. Able to balance complex user and organisational needs and use research to inform design, strategy and processes.
 
 #### Examples of behaviour and responsibilities
 

--- a/roles/sfia/senior_user_researcher.md
+++ b/roles/sfia/senior_user_researcher.md
@@ -84,8 +84,8 @@ Demonstrates leadership. Communicates effectively, both formally and informally
 
 Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
 
-- Supports the development of user research at MadeTech
-- Represents Madetech in the wider UCD community through writing or speaking
+- Supports the development of user research at Made Tech
+- Represents Made Tech in the wider UCD community through writing or speaking
 - Trustworthy, acts with integrity, openness and impartiality
 - Able to navigate and handle conflict within teams and with stakeholders
 - Can help colleagues understand how digital technology is changing user behaviour, and the challenges and opportunities for government services.

--- a/roles/sfia/user_researcher.md
+++ b/roles/sfia/user_researcher.md
@@ -1,75 +1,91 @@
-# SFIA Role Guidance: User Researcher 
+# SFIA Role Guidance: User Researcher
 
-* [SFIA Level 3](https://sfia-online.org/en/legacy-sfia/sfia-7/responsibilities/level-3)
-* [Job description](https://github.com/madetech/handbook/blob/main/roles/user_researcher.md)
+- [SFIA Level 3](https://sfia-online.org/en/legacy-sfia/sfia-7/responsibilities/level-3)
+- [Job description](https://github.com/madetech/handbook/blob/main/roles/user_researcher.md)
 
 ### Summary of role
+
 Our User Researchers work within service teams. They support the planning of user research activities and carry them out . They’re confident practitioners, able to support our seniors and leads to  plan and run user research as part of a team on public sector projects. They are contributors to our user-centred design (UCD) community and culture at Made Tech.
 
 ### Required competency for role (with example behaviours)
+
 ### Autonomy
+
 Works with guidance from Senior User researcher on the focus of work.  Can plan own user research activities to  design and deliver good public services with their team. Contributes to selecting the most appropriate methodologies for  producing the most impactful research outputs.  Supports the adoption of agreed approaches.
 
 #### Examples of behaviour and responsibilities
-Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
-- Able to give and receive feedback from the people they work with. Able to honestly self reflect.
-- Practices open and honest communication, active listening and demonstrates empathy and patience.
-- Take responsibility for their own work and decisions and participates in / supports  a no blame attitude in teams.
-- Shares good practice from own experience and looks to continually develop skills and knowledge of conducting activities like in-depth interviews with users or low fidelity prototypes.
-- Contributes to  community show and tells.
 
-### Influence 
+Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
+
+- Able to give and receive feedback from the people they work with. Able to honestly self reflect
+- Practices open and honest communication, active listening and demonstrates empathy and patience
+- Take responsibility for their own work and decisions and participates in / supports  a no blame attitude in teams
+- Shares good practice from own experience and looks to continually develop skills and knowledge of conducting activities like in-depth interviews with users or low fidelity prototypes
+- Contributes to  community show and tells
+
+### Influence
+
 Contributes to team success in research excellence.
 Able to explain research results and influence team, stakeholders and partners.
 
 #### Examples of behaviour and responsibilities
+
 Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
-- Able to understand, analyse and share research results to contribute to teams making decisions based on balancing research evidence against organisational needs and constraints.
-- Can explain and involve  stakeholders and teams in user centred design activities.
-- Understands the strategic vision of our clients that needs to be informed through user research.
-- Can  manage their time effectively to prioritise and plan activities. 
-- Is an advocate for users. Able to take direction from Senior User Researcher on the key needs.
-- Highlights decisions not informed by user research.
+
+- Able to understand, analyse and share research results to contribute to teams making decisions based on balancing research evidence against organisational needs and constraints
+- Can explain and involve  stakeholders and teams in user centred design activities
+- Understands the strategic vision of our clients that needs to be informed through user research
+- Can  manage their time effectively to prioritise and plan activities
+- Is an advocate for users. Able to take direction from Senior User Researcher on the key needs
+- Highlights decisions not informed by user research
 
 ### Complexity
-Conducts  user research in their team within a project that may be part of a wider programme of work in multi-organisation stakeholder environments. Conducts research to inform design, strategy and processes.  
+
+Conducts  user research in their team within a project that may be part of a wider programme of work in multi-organisation stakeholder environments. Conducts research to inform design, strategy and processes.
 
 #### Examples of behaviour and responsibilities
-Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
-- Conducts research activities with stakeholder groups.
-- Demonstrates understanding and empathy for stakeholders.
-- Produces research outputs that are suitable for the type of project, type of stakeholders and audience ensuring it has impact and leads to decision making.
-- Conducts research activities that enables working in an agile, open or user-centred way.
-- Shares results with all team members  within their team to ensure people in other disciplines working towards the same goals.
-- Has the ability to work in a fast-paced, evolving environment and use iterative methods and a flexible approach to enable rapid delivery.
-- Shares research with other delivery teams within the client organisation and shows the need for close coordination between teams.
 
-### Knowledge 
-Good understanding  of user research quantitative and qualitative methodologies and is able to assess and explore how and when to apply different approaches. 
+Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
+
+- Conducts research activities with stakeholder groups
+- Demonstrates understanding and empathy for stakeholders
+- Produces research outputs that are suitable for the type of project, type of stakeholders and audience ensuring it has impact and leads to decision making
+- Conducts research activities that enables working in an agile, open or user-centred way
+- Shares results with all team members  within their team to ensure people in other disciplines working towards the same goals
+- Has the ability to work in a fast-paced, evolving environment and use iterative methods and a flexible approach to enable rapid delivery
+- Shares research with other delivery teams within the client organisation and shows the need for close coordination between teams
+
+### Knowledge
+
+Good understanding  of user research quantitative and qualitative methodologies and is able to assess and explore how and when to apply different approaches.
 Has a range of quantitative and qualitative experience, and is competent with a range of methodologies.
 
 #### Examples of behaviour and responsibilities
+
 Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
-- Understands how and when to apply different methodologies across the design cycle.
-- Able to create appropriate, clear and compelling findings. 
-- Experience in how to deliver findings to reflect the needs of projects and clients to ensure strong outcomes.
-- Experience working with other user-centred design disciplines and a growing  understanding of how user research works cohesively with these disciplines. 
-- Understands how to apply basic techniques for analysis of research data and synthesis of findings. Knows how to involve their team in analysis and synthesis. Can present clear findings that colleagues can understand and use.
-- Understanding of how to include and consider and involve traditionally marginalised and oppressed groups.
-- Knowledge of how to conduct  ethical and inclusive research with a desire to develop and grow understanding.
+
+- Understands how and when to apply different methodologies across the design cycle
+- Able to create appropriate, clear and compelling findings
+- Experience in how to deliver findings to reflect the needs of projects and clients to ensure strong outcomes
+- Experience working with other user-centred design disciplines and a growing  understanding of how user research works cohesively with these disciplines
+- Understands how to apply basic techniques for analysis of research data and synthesis of findings. Knows how to involve their team in analysis and synthesis. Can present clear findings that colleagues can understand and use
+- Understanding of how to include and consider and involve traditionally marginalised and oppressed groups
+- Knowledge of how to conduct  ethical and inclusive research with a desire to develop and grow understanding
 
 ### Business Skills
 
-- Demonstrates effective communication skills.
-- Plans, schedules and monitors own work (and that of others where applicable) competently within limited deadlines and according to relevant legislation, standards and procedures.
-- Contributes fully to the work of teams. Appreciates how own role relates to other roles and to the business of the employer or client. Demonstrates an analytical and systematic approach to issue resolution.
-- Takes the initiative in identifying and negotiating appropriate personal development opportunities.
-- Understands how own role impacts security and demonstrates routine security practice and knowledge required for own work.
+- Demonstrates effective communication skills
+- Plans, schedules and monitors own work (and that of others where applicable) competently within limited deadlines and according to relevant legislation, standards and procedures
+- Contributes fully to the work of teams. Appreciates how own role relates to other roles and to the business of the employer or client. Demonstrates an analytical and systematic approach to issue resolution
+- Takes the initiative in identifying and negotiating appropriate personal development opportunities
+- Understands how own role impacts security and demonstrates routine security practice and knowledge required for own work
 
 #### Examples of behaviour and responsibilities
+
 Below are examples of behaviours and responsibilities a person in this role might be expected to demonstrate. The list is provided for illustrative purposes only.
-- Understands how and when to apply different methodologies across the design cycle.
-- Demonstrates willingness and an ability to support leadership. Communicates well, both formally and informally and is proactively working to develop communication skills.
-- Supports the development of user research at MadeTech.
-- Represents Madetech in the wider UCD community through writing or speaking. 
-- Trustworthy, acts with integrity, openness and impartiality when conducting and sharing user research. 
+
+- Understands how and when to apply different methodologies across the design cycle
+- Demonstrates willingness and an ability to support leadership. Communicates well, both formally and informally and is proactively working to develop communication skills
+- Supports the development of user research at Made Tech
+- Represents Made Tech in the wider UCD community through writing or speaking
+- Trustworthy, acts with integrity, openness and impartiality when conducting and sharing user research


### PR DESCRIPTION
The change was mainly to ensure `Made Tech` is referred to as such.

Other changes applied to edited files include:
- Consistently apply markdown lint rule [022](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md022---headers-should-be-surrounded-by-blank-lines)
- Consistently use `-` style for unordered lists in all user research role docs
- Consistently end bullet points with no full stop across all user search role docs