### PR TITLE
Update SFIA engineering roles references

### DIFF
--- a/roles/README.md
+++ b/roles/README.md
@@ -81,8 +81,8 @@ Leadership
 
 Software Engineering
  - [Academy Software Engineer](academy_software_engineer.md) ([SFIA Level 1](sfia/academy_software_engineer.md))
- - [Associate Software Engineer](associate_software_engineer.md) ([SFIA Level 2](sfia/software_engineer_1.md))
- - [Software Engineer](mid_software_engineer.md) ([SFIA Level 3](sfia/software_engineer_2.md))
+- [Associate Software Engineer](associate_software_engineer.md) ([SFIA Level 2](sfia/associate_software_engineer.md))
+- [Software Engineer](mid_software_engineer.md) ([SFIA Level 3](sfia/mid_software_engineer.md))
  - [Senior Software Engineer](senior_software_engineer.md) ([SFIA Level 4](sfia/senior_software_engineer.md))
  - [Lead Software Engineer](lead_software_engineer.md) ([SFIA Level 5](sfia/lead_software_engineer.md))
  - [Principal Software Engineer](principal_technologist.md) ([SFIA Level 6](sfia/principal_technologist.md))

--- a/roles/sfia/academy_software_engineer.md
+++ b/roles/sfia/academy_software_engineer.md
@@ -2,7 +2,7 @@
 
 [SFIA Level 1: Follow](https://sfia-online.org/en/sfia-7/responsibilities/level-1)
 
-[next &raquo;](software_engineer_1.md)
+[next &raquo;](associate_software_engineer.md)
 
 ## Summary of role
 

--- a/roles/sfia/associate_software_engineer.md
+++ b/roles/sfia/associate_software_engineer.md
@@ -1,8 +1,8 @@
-# SFIA Role Guidance: Software Engineer 1
+# SFIA Role Guidance: Associate Software Engineer
 
 [SFIA Level 2: Assist](https://sfia-online.org/en/sfia-7/responsibilities/level-2)
 
-[&laquo; previous](academy_software_engineer.md) | [next &raquo;](software_engineer_2.md)
+[&laquo; previous](academy_software_engineer.md) | [next &raquo;](mid_software_engineer.md)
 
 ## Summary of role
 

--- a/roles/sfia/mid_software_engineer.md
+++ b/roles/sfia/mid_software_engineer.md
@@ -1,8 +1,8 @@
-# SFIA Role Guidance: Software Engineer 2
+# SFIA Role Guidance: Software Engineer
 
 [SFIA Level 3: Apply](https://sfia-online.org/en/sfia-7/responsibilities/level-3)
 
-[&laquo; previous](software_engineer_1.md) | [next &raquo;](senior_software_engineer.md)
+[&laquo; previous](associate_software_engineer.md) | [next &raquo;](senior_software_engineer.md)
 
 ## Summary of role
 

--- a/roles/sfia/senior_software_engineer.md
+++ b/roles/sfia/senior_software_engineer.md
@@ -2,7 +2,7 @@
 
 [SFIA Level 4: Enable](https://sfia-online.org/en/sfia-7/responsibilities/level-4)
 
-[&laquo; previous](software_engineer_2.md) | [next &raquo;](lead_software_engineer.md)
+[&laquo; previous](mid_software_engineer.md) | [next &raquo;](lead_software_engineer.md)
 
 ## Summary of role
 


### PR DESCRIPTION
Summary:
The role titles for `Software Engineer 1` and `Software Engineer 2` have been changed to `Associate Software Engineer` and `Software Engineer`, however, there were still references to their past selves in the SFIA documentation. So, I just looked for them in the codebase and changed them.