### PR TITLE
Changing Flexible Leave to Fixed Leave

### DIFF
--- a/benefits/flexible_holiday.md
+++ b/benefits/flexible_holiday.md
@@ -48,7 +48,7 @@ It is the responsibility of the person agreeing to a holiday booking to ensure i
 
 * If a team members performance declines significantly due to abuse of this policy, then we reserve the right to review their use of this policy.
 
-* If you leave Made Tech part way through the year we will use 30 days to pro-rata your final salary. In some cases that means we'll pay you for accrued and unused holiday and in others it means you'll have to pay days taken over your pro-rated allowance back.
+* If you leave Made Tech part way through the year we will use 30 days (or your pro-rata days if you work part-time) to pro-rata your final salary. In some cases that means we'll pay you for accrued and unused holiday and in others it means you'll have to pay days taken over your pro-rated allowance back.
 
 ## Festive period at Made Tech 
 

--- a/benefits/flexible_holiday.md
+++ b/benefits/flexible_holiday.md
@@ -1,12 +1,12 @@
-# Flexible Holiday
+# Taking Holiday
 
 We're building a high-performance organisation that delivers great software products. We recognise that this requires a lot of hard work and that for our team to perform at their highest possible level, they need to live a well-balanced life and take regular time-out for rest, relaxation and rejuvenation.
 
-We have adopted a flexible holiday policy, where each team member is given the flexibility to take whatever holiday they need. We believe this policy will help us to perform at the highest possible level. We ensure everyone in the team take at least the minimum 23 days though welcome everyone to take more than this.
+All team members have 30 days of leave available between June and May. We believe this policy will help us to perform at the highest possible level.
 
-It is important that you and your colleagues feel that holiday is highly available. That holiday is an easily accessible commodity that enables everyone to get the necessary rest that they need. We intend untracked holiday to prevent burn-out in situations, where individuals feel that they need to "save up" holiday days, or plan elaborate strategies around using your holiday allowance "effectively" later in the year, rather than taking holiday when needed most.
+It is important that you and your colleagues feel that holiday is highly available. That holiday is an easily accessible commodity that enables everyone to get the necessary rest that they need. 
 
-Flexible Holiday is not meant as a way to regularly take large portions of time off work e.g. 1 week every month, or 4 months off straight.  Made Tech will support holiday requests that are up to 4 consecutive weeks, if you wish to take longer than this the additional time may be unpaid. Please see our [Flexible Working](flexible_working.md) as the alternative to Flexible Holiday in those situations.
+Made Tech will support holiday requests that are up to 4 consecutive weeks, if you wish to take longer than this the additional time may be unpaid. Please see our [Flexible Working](flexible_working.md) as the alternative to Flexible Holiday in those situations.
 
 ## How long are you taking?
 
@@ -48,7 +48,7 @@ It is the responsibility of the person agreeing to a holiday booking to ensure i
 
 * If a team members performance declines significantly due to abuse of this policy, then we reserve the right to review their use of this policy.
 
-* We have 23 holiday days in our employment contracts but in practice we have Flexible Holiday as per this guidance. We'd only revert to the employment contract in the case of abusing our Flexible Holiday system though we've never needed to do this. If you leave Made Tech part way through the year we will also use 23 days to pro-rata your final salary. In some cases that means we'll pay you for accrued and unused holiday and in others it means you'll have to pay days taken over your pro-rated allowance back.
+* If you leave Made Tech part way through the year we will use 30 days to pro-rata your final salary. In some cases that means we'll pay you for accrued and unused holiday and in others it means you'll have to pay days taken over your pro-rated allowance back.
 
 ## Festive period at Made Tech 
 

--- a/benefits/flexible_holiday.md
+++ b/benefits/flexible_holiday.md
@@ -2,7 +2,7 @@
 
 We're building a high-performance organisation that delivers great software products. We recognise that this requires a lot of hard work and that for our team to perform at their highest possible level, they need to live a well-balanced life and take regular time-out for rest, relaxation and rejuvenation.
 
-All team members have 30 days of leave available between June and May. We believe this policy will help us to perform at the highest possible level.
+All team members have 30 days of leave available between June and May (pro-rata for part time colleagues), plus bank holidays. We believe this policy will help us to perform at the highest possible level.
 
 It is important that you and your colleagues feel that holiday is highly available. That holiday is an easily accessible commodity that enables everyone to get the necessary rest that they need. 
 


### PR DESCRIPTION
Flexible leave will end on 31/12/200
This update is to update the guidance to align with our updated holiday benefit which will make a fixed pot of leave available to all team members. The total holiday available is set to 30 days between June and May, changing from January to December, which is to align it to our financial year.