### PR TITLE
Mark start00 linux set up

### DIFF
--- a/guides/it/linux_av.md
+++ b/guides/it/linux_av.md
@@ -61,12 +61,12 @@ This will:
 
 ### Linux (Ubuntu) 22.04+
 pam_tally2.so has been replaced by pam_faillock.so <br>
-pam_failock.so settings can be made in `/etc/security/faillock.conf` and by adding the following to `/etc/pam.d/common-auth`:
+pam_failock.so settings can be made in `/etc/security/faillock.conf` and by adding the following to the `/etc/pam.d/common-auth` file:
 ```
 auth    [default=die]   pam_faillock.so     authfail
 auth    sufficient      pam_faillock.so     authsucc
 ```
-If you have prevented all logins by mistake with pam_tally2 you can reboot to recovery mode in# All about Linux
+If you have prevented all logins by mistake with pam_tally2 you can reboot to recovery mode into a root shell to access `/etc/pam.d/common-auth`.
 
 #### Root account
 [Ubuntu disables the root account by default](https://ubuntu.com/server/docs/security-users) by not setting a password. This allows a user to boot into a root shell via GRUB / recovery mode. To prevent this you should set a password for the root user:

--- a/guides/it/linux_av.md
+++ b/guides/it/linux_av.md
@@ -1,9 +1,9 @@
 # All about Linux
-In order to reach the standards for [Cyber Essentials Plus](https://www.ncsc.gov.uk/cyberessentials/overview), all our laptops must meet a certain set of requirements. For Mac and Windows machines that is controlled remotely by our IT Partner. For Linux machines that currently all needs to be done manually.
+In order to reach the standards for [ISO](https://www.madetech.com/blog/iso-27001-changes/) and [Cyber Essentials Plus](https://www.ncsc.gov.uk/cyberessentials/overview), all our laptops must meet a certain set of requirements. For Mac and Windows machines that is controlled remotely by our IT Partner Systemagic. For Linux machines that currently all needs to be done manually.
 
-The documentation below is valid in places and out of date (but not incorrect) in others. A new set of standards is being put together but it won't be ready until January 2022. At that point this new information will move on to the Knowledge Base.
+The documentation below is valid in places and out of date (but not incorrect) in others. A new set of standards is being put together but it won't be ready until January 2022. At that point this new information will move to the internally facing Knowledge Base.
 
-In the meantime, any questions to [operations@madetech.com](mailto:operations@madetech.com) or the #linuxination Slack channel.
+In the meantime, Welcome, if you have any questions please ask [operations@madetech.com](mailto:operations@madetech.com) and join the #linuxination Slack channel! Everybody really likes Linux so whether you are new to Linux or a Linux wizard we all like questions and are all here to help.
 
 
 
@@ -12,6 +12,21 @@ The operating system must be a current, supported version, that continues to rec
 
 ### Linux (Ubuntu)
 Check [Ubuntu releases](https://wiki.ubuntu.com/Releases) to ensure that your version is supported.
+
+## Full disk encryption
+**This is the most important step**. When you install your operating system there will be a checkbox to enable this. Please set a disk encryption password that fits the [password policy](https://github.com/madetech/handbook/blob/7d4a7f840a587fed5046045cbe43f8222cabb194/guides/security/password_policy.md).
+
+It may be possible to encrypt dual booted or manual partitions but it is simpler to erase the disk and follow the guided installation for one operating system.
+
+For Ubuntu select `Erase disk and install Ubuntu`, `Advanced features`, `Use LVM`, `Encrypt the new Ubuntu installation`. In the next step you will be able to set security and recovery keys. Don't forget them!
+
+(Note: Enabling full disk encryption after installation is a difficult and dangerous process that is best not attempted. It is most likely you will have to complete all the following steps again after a fresh (disk encrypted) install).
+
+## Automatic updates enabled
+Security updates need to be downloaded and installed automatically (Note: it is up to users on when to apply non-security related updates). Both Ubuntu and Fedora have provisions to enable this:
++ [Ubuntu](https://help.ubuntu.com/community/AutomaticSecurityUpdates#Using_GNOME_Update_Manager)
++ [Fedora](https://fedoraproject.org/wiki/AutoUpdates#Automatic_Updates)
+
 
 ## User accounts
 The user account that you use on a day to day basis must be a standard non-administrator account. If you require administrator rights to do your job, you can create a separate admin user and switch to this when required.
@@ -29,7 +44,7 @@ exit
 ```
 
 ## Account locking
-User accounts should be configured to lock after a **maximum** of 10 failed login attempts.
+User accounts should be configured to lock after a **maximum** of 10 failed login attempts for 5 minutes, log the username to the syslog if the user is not found, and apply the same settings to the root user account.
 
 ### Linux (Ubuntu)
 To enable account locking on Ubuntu add the following line to `/etc/pam.d/common-auth`, directly after the `# here are the per-package modules (the "Primary" block)` comment:
@@ -46,14 +61,12 @@ This will:
 
 ### Linux (Ubuntu) 22.04+
 pam_tally2.so has been replaced by pam_faillock.so <br>
-pam_failock.so settings can be made in `/etc/security/faillock.conf` and by adding:
+pam_failock.so settings can be made in `/etc/security/faillock.conf` and by adding the following to `/etc/pam.d/common-auth`:
 ```
 auth    [default=die]   pam_faillock.so     authfail
 auth    sufficient      pam_faillock.so     authsucc
 ```
-to `/etc/pam.d/common-auth`.
-If you have prevented all logins by mistake with pam_tally2 you can reboot into recovery mode to a root shell prompt to access `/etc/pam.d/common-auth`.
-
+If you have prevented all logins by mistake with pam_tally2 you can reboot to recovery mode in# All about Linux
 
 #### Root account
 [Ubuntu disables the root account by default](https://ubuntu.com/server/docs/security-users) by not setting a password. This allows a user to boot into a root shell via GRUB / recovery mode. To prevent this you should set a password for the root user:
@@ -89,8 +102,8 @@ You must be running Anti-virus software. The installed AV software must:
 
 You can test the configuration of your AV software using the test files provided by [EICAR](https://www.eicar.org/) on their ["Anti Malware Testfile" page](https://www.eicar.org/?page_id=3950). For example, after downloading `eicar.com.txt` it should not be possible to open the file in a text editor.
 
-## SentinalOne
-SentinelOne is the Linux Anti-virus Software of choice at Made Tech. To get set up with SentinalOne follow the instructions below
+## SentinelOne
+SentinelOne is the Linux Anti-virus Software of choice at Made Tech. To get set up with SentinelOne follow the instructions below
 
 ### Step 1: Download and install the package
 * [DEB Installer](https://ncrepository.z33.web.core.windows.net/sentinelone/SentinelAgent-Linux-22-1-2-7-x86-64-release-22-1-2_linux_v22_1_2_7.deb) - For Debian/Ubuntu based distributions
@@ -111,11 +124,11 @@ or
 sudo rpm -i --nodigest ~/Downloads/Signed-SentinelAgent-Linux-22-1-2-7-x86-64-release-22-1-2_linux_v22_1_2_7.rpm
 ```
 
-### Step 2: Register the Made Tech license key to your SentinalOne install 
+### Step 2: Register the Made Tech licence key to your SentinelOne install 
 
-You can find the license key in 1Password.
+You can find the licence key in 1Password.
 ```
-sudo /opt/sentinelone/bin/sentinelctl management token set [license_key]
+sudo /opt/sentinelone/bin/sentinelctl management token set [licence_key]
 ```
 
 ### Step 3: Start the Service
@@ -123,8 +136,13 @@ sudo /opt/sentinelone/bin/sentinelctl management token set [license_key]
 sudo /opt/sentinelone/bin/sentinelctl control start
 ```
 
-Once installed and you've started the service check with Ops to ensure you have registered to the SentinalOne dashboard successfully. If this was successful you can remove your previous Anti-virus solution. Should you face any problems or require support please reach out to #ops-it-support or #linuxination on Slack
+Once installed, and you've started the service check with Ops to ensure you have registered to the SentinelOne dashboard successfully. If this was successful you can remove your previous Anti-virus solution. Should you face any problems or require support please reach out to #ops-it-support or #linuxination on Slack
 
+## DriveStrike
+DriveStrike must also be installed on all Linux machines. It is owned and managed by the awesome Systemagic! You will receive an email from DriveStrike with an invitation to install DriveStrike shortly after starting although it is the individual's responsibility to ensure it is on their machine and the service is enabled.
+
+## Approved software
+For Linux users anything downloaded from the main stable repositories is considered safe to install on your device.
 
 ## UEFI Settings
 


### PR DESCRIPTION
I cross-checked the handbook linux_av with the knowledge base (kb) [linux requirements](https://docs.google.com/document/d/13_Je82eCpPU2qZgYINxDYX9OxRrVemdixj8yD4IFH8s/edit).

The important sections I added:
- Full disk encryption
- Automatic updates enabled
- DriveStrike

I added a few helpful section and information taken from the kb linux requirements :
- Approved software
- Account locking details (I think these are iso requirments to pass the audit)
- ISO hyperlink ( it points to the Made Tech blog for iso 27001 - I thought it was helpful - but it can point to iso.org).

I ran a spellcheck (making it seem like I've made more changes than I have!):
- SentinalOne <-- SentinelOne
- license <-- licence (english spelling not sure if it was important to change).

And made some small changes welcoming Linux starters (although please delete it it isn't the right tone) and some small changes that felt more correct when I fresh installed my system to encrypt the disk and went through the setup check list again.
I think it will save time for a new starter and adds some helpful information from my new starter perspective! 
But please feel free to change anything. Or maybe adding a section to point new starters to the kb instead of the av ?



