### PR TITLE
Update how_to_timesheet.md

### DIFF
--- a/guides/process/scheduling/how_to_timesheet.md
+++ b/guides/process/scheduling/how_to_timesheet.md
@@ -4,7 +4,7 @@
 
 We use [Kimble](https://www.kimbleapps.com/) to complete timesheets. All resources on how to complete and approve timesheets are in the [Knowledge base](https://sites.google.com/madetech.com/signpost/home/kimble-resources?authuser=0) (including a link for login through Single Sign-On (SSO)). 
 
-Made Tech hours are 35 per week, 7 hours per day full time. Part-time hours are prorated according to your agreed hours.
+Made Tech billable hours are 35 per week, 7 hours per day full time. Part-time hours are prorated according to your agreed hours.
 
 Only billable team members need to complete a timesheet (including contractors) and you will be notified at your onboarding session if you need to complete one. The timesheet must be completed to account for all of your time in the working week (excluding contractors).
 


### PR DESCRIPTION
Minor amendment to clarify that 35 hours of timesheet time expected each week reflect billable time. 

Further work needed in future to update this page to reflect updates to time categories; and create greater clarity on the relationship between 'billable hours' and internal activities on top of these. Ops team to pick this up in the next 1-2 months.