### PR TITLE
Upgrade version of Node used in CI to a supported version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
 
     - uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: '18'
         cache: 'npm'
 
     - run: npm ci


### PR DESCRIPTION
package-lock.json has a lockfileVersion of 3, which is introduced in npmv9

We were previously using npmv6 which isn't compatible