### PR TITLE
AWS Partner account linking steps based on current UI

### DIFF
--- a/guides/cloud/aws_partner_certs.md
+++ b/guides/cloud/aws_partner_certs.md
@@ -50,7 +50,7 @@ In order for your AWS Certifications to appear within the Made Tech AWS Partner 
 
 1. [Log in to the AWS Partner Network](https://partnercentral.awspartner.com/APNLogin) with your `@madetech.com` email address.
 2. Click on `My profile` from the top right hand menu, and select `My AWS Certifications`.
-3. Click the `Edit` button in the `View all Trainings and Certifications` box.
+3. Click the `Edit` button in the `View All Trainings and Certifications` box.
 4. Add your personal AWS Certification email address to the `AWS T&C Account Email` field, and click `Verify email`. Copy the verification code you received at your personal email address and paste it into the `Enter Verification Code` field, and click `Verify code`.
 5. Once verified, select `Yes` for `I consent to share my AWS Certifications with "Made Tech" *`.
 
@@ -71,6 +71,6 @@ The recommended AWS Partner training path for technical roles is the [AWS Techni
 When an employee leaves Made Tech, they should unlink their personal Certification email address from their `@madetech.com` AWS Partner Account. This should be done while they have access to their `@madetech.com` email address as part of their offboarding.
 
 1. [Log in to the AWS Partner Network](https://partnercentral.awspartner.com/APNLogin) with your `@madetech.com` email address.
-2. Click on `View My Profile` from the left hand `QUICK LINKS` menu.
-3. Click the blue `Edit` button.
-4. Under `AWS CERTIFICATION` remove your personal AWS Certification email address to the `AWS T&C Account Email` field, and select `No` for `I consent to share my AWS Certifications with "Made Tech" *`
+2. Click on `My profile` from the top right hand menu, and select `My AWS Certifications`.
+3. Click the `Edit` button in the `View All Trainings and Certifications` box.
+4. Remove your personal AWS Certification email address to the `AWS T&C Account Email` field, and select `No` for `I consent to share my AWS Certifications with "Made Tech" *`.


### PR DESCRIPTION
Updated the steps for linking MadeTech AWS Partner account with personal certification account based on the current UI.